### PR TITLE
Remap htmldocx styleIds to localized template styles

### DIFF
--- a/app/services/document_service.py
+++ b/app/services/document_service.py
@@ -527,6 +527,7 @@ class DocumentService:
         # Insert each element from temp_doc after the placeholder paragraph
         para_element = after_para._element
         insert_point = para_element
+        inserted_elements = []
         for element in temp_doc.element.body:
             # Skip section properties (sectPr)
             if element.tag.endswith('sectPr'):
@@ -535,6 +536,157 @@ class DocumentService:
             new_element = deepcopy(element)
             insert_point.addnext(new_element)
             insert_point = new_element
+            inserted_elements.append(new_element)
+
+        # htmldocx writes hard-coded English styleIds (Heading1, ListBullet, ...).
+        # These only resolve in templates built in English Word. For localized
+        # templates (e.g. French uses styleId=Titre1) the styleIds don't exist
+        # and Word falls back to defaults, losing the template's look and feel.
+        # Remap them to the target template's actual styleIds via the canonical
+        # <w:name> (which is invariant across languages for built-in styles).
+        self._remap_inserted_style_ids(doc, inserted_elements)
+
+    # Canonical <w:name> values used by Word for the built-in styles that
+    # htmldocx may emit. Matching is case-insensitive and space-insensitive.
+    _HTMLDOCX_STYLE_CANONICAL_NAMES = {
+        "Heading1": "heading 1",
+        "Heading2": "heading 2",
+        "Heading3": "heading 3",
+        "Heading4": "heading 4",
+        "Heading5": "heading 5",
+        "Heading6": "heading 6",
+        "Heading7": "heading 7",
+        "Heading8": "heading 8",
+        "Heading9": "heading 9",
+        "Title": "title",
+        "Subtitle": "subtitle",
+        "ListBullet": "list bullet",
+        "ListNumber": "list number",
+        "ListParagraph": "list paragraph",
+        "Quote": "quote",
+        "IntenseQuote": "intense quote",
+        "Caption": "caption",
+    }
+
+    _STYLE_OVERRIDE_PROPERTY_PREFIX = "style_"
+
+    def _remap_inserted_style_ids(self, doc, inserted_elements) -> None:
+        """Rewrite pStyle/@val on freshly inserted paragraphs so they point at
+        styles that actually exist in the target template.
+
+        Resolution order per htmldocx styleId (e.g. "Heading1"):
+          1. Document custom property `style_heading1` -> explicit override.
+          2. Style in the template whose <w:name> matches the canonical name
+             ("heading 1") case-insensitively.
+          3. Leave the original styleId untouched (legacy behavior).
+        """
+        W_NS = "http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+        W = "{" + W_NS + "}"
+
+        def norm(s: str) -> str:
+            return (s or "").strip().lower()
+
+        name_to_id: Dict[str, str] = {}
+        for style_el in doc.styles.element.findall(W + "style"):
+            sid = style_el.get(W + "styleId")
+            if not sid:
+                continue
+            name_el = style_el.find(W + "name")
+            if name_el is None:
+                continue
+            name_val = name_el.get(W + "val")
+            if not name_val:
+                continue
+            # First entry wins so the primary style for a given name beats
+            # later duplicates (e.g. linked character styles).
+            name_to_id.setdefault(norm(name_val), sid)
+
+        overrides: Dict[str, str] = self._read_style_overrides(doc)
+
+        # Build the final mapping htmldocx_id -> resolved template styleId.
+        resolved: Dict[str, str] = {}
+        for htmldocx_id, canonical_name in self._HTMLDOCX_STYLE_CANONICAL_NAMES.items():
+            override = overrides.get(htmldocx_id.lower())
+            if override:
+                resolved[htmldocx_id] = override
+                continue
+            match = name_to_id.get(canonical_name)
+            if match and match != htmldocx_id:
+                resolved[htmldocx_id] = match
+
+        if not resolved:
+            return
+
+        for root in inserted_elements:
+            for pstyle in root.iter(W + "pStyle"):
+                current = pstyle.get(W + "val")
+                target = resolved.get(current)
+                if target:
+                    pstyle.set(W + "val", target)
+
+    _CUSTOM_PROPS_CONTENT_TYPE = (
+        "application/vnd.openxmlformats-officedocument.custom-properties+xml"
+    )
+    _CUSTOM_PROPS_NS = (
+        "http://schemas.openxmlformats.org/officeDocument/2006/custom-properties"
+    )
+    _CUSTOM_PROPS_VT_NS = (
+        "http://schemas.openxmlformats.org/officeDocument/2006/docPropsVTypes"
+    )
+
+    def _read_style_overrides(self, doc) -> Dict[str, str]:
+        """Read style overrides from the document's custom properties.
+
+        A template author can declare, via File > Info > Properties > Advanced
+        in Word, a custom property like `style_heading1 = TitreOrange` to force
+        inserted H1 paragraphs onto that style. Keys are matched
+        case-insensitively against htmldocx styleIds (heading1, listbullet...).
+
+        python-docx 1.2 does not expose custom properties, so we read the raw
+        `/docProps/custom.xml` part directly.
+        """
+        import xml.etree.ElementTree as ET
+
+        try:
+            package = doc.part.package
+        except Exception:
+            return {}
+
+        custom_part = None
+        try:
+            for part in package.iter_parts():
+                if getattr(part, "content_type", None) == self._CUSTOM_PROPS_CONTENT_TYPE:
+                    custom_part = part
+                    break
+        except Exception:
+            return {}
+
+        if custom_part is None:
+            return {}
+
+        try:
+            blob = custom_part.blob
+            root = ET.fromstring(blob)
+        except Exception:
+            return {}
+
+        ns = {"p": self._CUSTOM_PROPS_NS, "vt": self._CUSTOM_PROPS_VT_NS}
+        overrides: Dict[str, str] = {}
+        for prop in root.findall("p:property", ns):
+            name = prop.get("name") or ""
+            if not name.lower().startswith(self._STYLE_OVERRIDE_PROPERTY_PREFIX):
+                continue
+            # Value is in a vt:* child element (lpwstr, bstr, i4, ...).
+            value_el = None
+            for child in prop:
+                if child.tag.startswith("{" + self._CUSTOM_PROPS_VT_NS + "}"):
+                    value_el = child
+                    break
+            if value_el is None or not (value_el.text or "").strip():
+                continue
+            htmldocx_key = name[len(self._STYLE_OVERRIDE_PROPERTY_PREFIX):].lower()
+            overrides[htmldocx_key] = value_el.text.strip()
+        return overrides
 
     def _get_result_content(self, job: Job) -> str:
         """Extract text content from job result."""

--- a/tests/test_document_service_style_remap.py
+++ b/tests/test_document_service_style_remap.py
@@ -1,0 +1,313 @@
+#!/usr/bin/env python3
+"""
+Tests for DocumentService._insert_markdown_content style remapping.
+
+The pipeline uses htmldocx which hard-codes English styleIds (Heading1,
+ListBullet, ...). Localized templates (e.g. French uses styleId=Titre1 with
+w:name="heading 1") must have those styleIds remapped via the canonical name,
+otherwise the template's look and feel is lost on the inserted content.
+"""
+import zipfile
+from io import BytesIO
+from unittest.mock import MagicMock
+
+import pytest
+from docx import Document
+from lxml import etree
+
+from app.services.document_service import DocumentService
+
+
+W_NS = "http://schemas.openxmlformats.org/wordprocessingml/2006/main"
+W = "{" + W_NS + "}"
+
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+def _add_style(doc, style_id: str, name: str, based_on: str | None = None):
+    """Inject a minimal <w:style> element into doc.styles.element.
+
+    python-docx's add_style would derive the styleId from the name, which is
+    exactly what we want to avoid (we need styleId=Titre1 with name='heading 1').
+    """
+    style_el = etree.SubElement(doc.styles.element, W + "style")
+    style_el.set(W + "type", "paragraph")
+    style_el.set(W + "styleId", style_id)
+    name_el = etree.SubElement(style_el, W + "name")
+    name_el.set(W + "val", name)
+    if based_on:
+        bo = etree.SubElement(style_el, W + "basedOn")
+        bo.set(W + "val", based_on)
+    return style_el
+
+
+def _drop_styles_named(doc, names_lower: set[str]):
+    """Remove styles from a Document whose <w:name> (case-insensitive) is in
+    the given set. Used to undo python-docx's default English heading styles
+    so tests can simulate a localized-only template."""
+    root = doc.styles.element
+    for style_el in list(root.findall(W + "style")):
+        name_el = style_el.find(W + "name")
+        if name_el is None:
+            continue
+        val = (name_el.get(W + "val") or "").strip().lower()
+        if val in names_lower:
+            root.remove(style_el)
+
+
+def _make_french_styled_doc():
+    """Return a fresh Document with French-style ids (Titre1, Listepuces)
+    whose canonical w:name matches Word's built-in names. The default English
+    heading/list styles are stripped so the template behaves like one authored
+    in a French Word."""
+    doc = Document()
+    _drop_styles_named(
+        doc,
+        {
+            "heading 1", "heading 2", "heading 3",
+            "heading 4", "heading 5", "heading 6",
+            "heading 7", "heading 8", "heading 9",
+            "list bullet", "list number", "list paragraph",
+        },
+    )
+    _add_style(doc, "Titre1", "heading 1")
+    _add_style(doc, "Titre2", "heading 2")
+    _add_style(doc, "Titre3", "heading 3")
+    _add_style(doc, "Listepuces", "List Bullet")
+    return doc
+
+
+def _make_paragraph_with_pstyle(style_val: str):
+    """Build a minimal <w:p> element carrying a pStyle reference."""
+    p = etree.Element(W + "p")
+    ppr = etree.SubElement(p, W + "pPr")
+    pstyle = etree.SubElement(ppr, W + "pStyle")
+    pstyle.set(W + "val", style_val)
+    r = etree.SubElement(p, W + "r")
+    t = etree.SubElement(r, W + "t")
+    t.text = "dummy"
+    return p
+
+
+def _pstyle_vals(root):
+    return [
+        pstyle.get(W + "val")
+        for pstyle in root.iter(W + "pStyle")
+    ]
+
+
+# =============================================================================
+# _remap_inserted_style_ids
+# =============================================================================
+
+class TestRemapInsertedStyleIds:
+    def test_remaps_english_ids_to_french_via_canonical_name(self):
+        """Heading1 -> Titre1 (and friends) when template has FR style ids
+        whose w:name matches Word's canonical english names."""
+        svc = DocumentService()
+        doc = _make_french_styled_doc()
+
+        inserted = [
+            _make_paragraph_with_pstyle("Heading1"),
+            _make_paragraph_with_pstyle("Heading2"),
+            _make_paragraph_with_pstyle("Heading3"),
+            _make_paragraph_with_pstyle("ListBullet"),
+        ]
+
+        svc._remap_inserted_style_ids(doc, inserted)
+
+        assert _pstyle_vals(inserted[0]) == ["Titre1"]
+        assert _pstyle_vals(inserted[1]) == ["Titre2"]
+        assert _pstyle_vals(inserted[2]) == ["Titre3"]
+        assert _pstyle_vals(inserted[3]) == ["Listepuces"]
+
+    def test_leaves_ids_untouched_when_template_already_has_english_ids(self):
+        """No-op when the target template already uses Heading1/Heading2."""
+        svc = DocumentService()
+        doc = Document()
+        # python-docx's default template already defines Heading 1 etc.
+        _add_style(doc, "Heading1", "heading 1")
+        _add_style(doc, "Heading2", "heading 2")
+
+        inserted = [
+            _make_paragraph_with_pstyle("Heading1"),
+            _make_paragraph_with_pstyle("Heading2"),
+        ]
+
+        svc._remap_inserted_style_ids(doc, inserted)
+
+        assert _pstyle_vals(inserted[0]) == ["Heading1"]
+        assert _pstyle_vals(inserted[1]) == ["Heading2"]
+
+    def test_leaves_unresolvable_id_untouched(self):
+        """If the template has no matching w:name, the original styleId is
+        left in place (legacy fallback, no regression)."""
+        svc = DocumentService()
+        doc = Document()
+        _drop_styles_named(
+            doc,
+            {"heading 1", "list bullet", "list number", "list paragraph"},
+        )
+        # Only heading 1 exists in this template — no bullet list equivalent.
+        _add_style(doc, "Titre1", "heading 1")
+
+        inserted = [
+            _make_paragraph_with_pstyle("Heading1"),
+            _make_paragraph_with_pstyle("ListBullet"),
+        ]
+
+        svc._remap_inserted_style_ids(doc, inserted)
+
+        assert _pstyle_vals(inserted[0]) == ["Titre1"]
+        assert _pstyle_vals(inserted[1]) == ["ListBullet"]  # unchanged
+
+    def test_custom_property_override_wins_over_name_match(self):
+        """An explicit `style_heading1 = SomeStyle` custom property must
+        override the canonical-name match."""
+        svc = DocumentService()
+        doc = _make_french_styled_doc()
+        _add_style(doc, "TitreOrange", "Titre Orange")
+
+        # Monkey-patch the override reader to simulate a custom property.
+        svc._read_style_overrides = lambda _doc: {"heading1": "TitreOrange"}
+
+        inserted = [
+            _make_paragraph_with_pstyle("Heading1"),
+            _make_paragraph_with_pstyle("Heading2"),
+        ]
+
+        svc._remap_inserted_style_ids(doc, inserted)
+
+        assert _pstyle_vals(inserted[0]) == ["TitreOrange"]
+        # Heading2 has no override, falls back to canonical-name match.
+        assert _pstyle_vals(inserted[1]) == ["Titre2"]
+
+    def test_no_styles_means_no_crash(self):
+        """Empty inserted list is a safe no-op."""
+        svc = DocumentService()
+        doc = Document()
+        svc._remap_inserted_style_ids(doc, [])  # should not raise
+
+
+# =============================================================================
+# _read_style_overrides
+# =============================================================================
+
+CUSTOM_XML_TEMPLATE = b"""<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<Properties xmlns="http://schemas.openxmlformats.org/officeDocument/2006/custom-properties" xmlns:vt="http://schemas.openxmlformats.org/officeDocument/2006/docPropsVTypes">
+<property fmtid="{D5CDD505-2E9C-101B-9397-08002B2CF9AE}" pid="2" name="style_heading1"><vt:lpwstr>TitreOrange</vt:lpwstr></property>
+<property fmtid="{D5CDD505-2E9C-101B-9397-08002B2CF9AE}" pid="3" name="style_listbullet"><vt:lpwstr>Listepuces</vt:lpwstr></property>
+<property fmtid="{D5CDD505-2E9C-101B-9397-08002B2CF9AE}" pid="4" name="Company"><vt:lpwstr>ACME</vt:lpwstr></property>
+</Properties>
+"""
+
+
+class _FakePart:
+    def __init__(self, content_type: str, blob: bytes):
+        self.content_type = content_type
+        self.blob = blob
+
+
+class _FakePackage:
+    def __init__(self, parts):
+        self._parts = parts
+
+    def iter_parts(self):
+        return iter(self._parts)
+
+
+def _make_doc_with_custom_props(xml_blob: bytes | None):
+    """Return a fake 'doc' with just enough structure to satisfy
+    _read_style_overrides."""
+    parts = []
+    if xml_blob is not None:
+        parts.append(
+            _FakePart(
+                DocumentService._CUSTOM_PROPS_CONTENT_TYPE,
+                xml_blob,
+            )
+        )
+    # A decoy part to prove the filter works.
+    parts.append(_FakePart("application/xml", b"<ignored/>"))
+
+    doc = MagicMock()
+    doc.part.package = _FakePackage(parts)
+    return doc
+
+
+class TestReadStyleOverrides:
+    def test_parses_style_prefixed_properties_only(self):
+        svc = DocumentService()
+        doc = _make_doc_with_custom_props(CUSTOM_XML_TEMPLATE)
+
+        overrides = svc._read_style_overrides(doc)
+
+        assert overrides == {
+            "heading1": "TitreOrange",
+            "listbullet": "Listepuces",
+        }
+        # Non-style custom property ("Company") is ignored.
+        assert "company" not in overrides
+
+    def test_returns_empty_when_no_custom_part(self):
+        svc = DocumentService()
+        doc = _make_doc_with_custom_props(None)
+
+        assert svc._read_style_overrides(doc) == {}
+
+    def test_returns_empty_on_malformed_xml(self):
+        svc = DocumentService()
+        doc = _make_doc_with_custom_props(b"not xml at all <<<")
+
+        assert svc._read_style_overrides(doc) == {}
+
+
+# =============================================================================
+# _insert_markdown_content — end-to-end
+# =============================================================================
+
+class TestInsertMarkdownContentEndToEnd:
+    def test_headings_adopt_french_styleids_after_insertion(self):
+        """Full pipeline: markdown -> htmldocx -> remap -> paragraphs in the
+        doc carry the template's localized styleIds."""
+        pytest.importorskip("htmldocx")
+        pytest.importorskip("markdown")
+
+        svc = DocumentService()
+        doc = _make_french_styled_doc()
+        target = doc.add_paragraph("placeholder")
+
+        md = (
+            "# Mon H1\n\n"
+            "Un paragraphe.\n\n"
+            "## Mon H2\n\n"
+            "- item A\n"
+            "- item B\n\n"
+            "### Mon H3\n\n"
+            "Fin.\n"
+        )
+
+        svc._insert_markdown_content(doc, target, md)
+
+        # Save -> reload to assert the serialized document is consistent.
+        buf = BytesIO()
+        doc.save(buf)
+        buf.seek(0)
+        with zipfile.ZipFile(buf) as z:
+            document_xml = z.read("word/document.xml")
+        tree = etree.fromstring(document_xml)
+
+        by_text = {}
+        for p in tree.iter(W + "p"):
+            text = "".join(t.text or "" for t in p.iter(W + "t"))
+            pstyle = p.find(W + "pPr/" + W + "pStyle")
+            sid = pstyle.get(W + "val") if pstyle is not None else None
+            by_text[text.strip()] = sid
+
+        assert by_text.get("Mon H1") == "Titre1"
+        assert by_text.get("Mon H2") == "Titre2"
+        assert by_text.get("Mon H3") == "Titre3"
+        assert by_text.get("item A") == "Listepuces"
+        assert by_text.get("item B") == "Listepuces"


### PR DESCRIPTION
## Summary
- htmldocx writes hard-coded English styleIds (`Heading1`, `ListBullet`, `Title`, …) into the inserted paragraphs.
- These only resolve in English Word templates. In localized templates (e.g. French, where `Heading1` becomes `Titre1`), Word falls back to Normal and loses the template's look.
- Remap the styleIds on freshly inserted paragraphs to the template's actual styleIds via the canonical `<w:name>` (invariant across languages for built-in styles).
- Also supports per-style overrides via document custom properties (`style_heading1`, …).

## Test plan
- [x] Unit tests in `tests/test_document_service_style_remap.py` cover: exact-match canonical name, custom property override, unknown style fallback.
- [ ] Manual check on a French template: Heading levels and bullet lists retain the template styling.