### PR TITLE
Fix/template export

### DIFF
--- a/app/api/v1/services.py
+++ b/app/api/v1/services.py
@@ -737,6 +737,11 @@ async def execute_service(
     # Generate Celery task ID upfront so we can create the job record first
     celery_task_id = str(uuid_module.uuid4())
 
+    # Extract caller-supplied display names from the request metadata.
+    meta = request.metadata or {}
+    conversation_name = meta.get("conversation_name")
+    organization_name = meta.get("organization_name")
+
     # Create job record FIRST
     job = await job_service.create_job(
         db=db,
@@ -744,6 +749,8 @@ async def execute_service(
         flavor_id=flavor.id,
         celery_task_id=celery_task_id,
         organization_id=None,  # TODO: Extract from auth
+        organization_name=organization_name,
+        conversation_name=conversation_name,
         input_file_name=None,
         input_preview=content[:500] if isinstance(content, str) else str(content)[:500],
         # Fallback tracking
@@ -800,6 +807,8 @@ async def _execute_with_file_internal(
     organization_id: Optional[str],
     db,
     context_data: Optional[Dict[str, Any]] = None,
+    organization_name: Optional[str] = None,
+    conversation_name: Optional[str] = None,
 ):
     """
     Internal implementation for file-based execution with context validation.
@@ -1026,6 +1035,8 @@ async def _execute_with_file_internal(
         flavor_id=flavor.id,
         celery_task_id=celery_task_id,
         organization_id=organization_id,
+        organization_name=organization_name,
+        conversation_name=conversation_name,
         input_file_name=input_file_name,
         input_preview=content[:500] if content else "",
         # Fallback tracking
@@ -1090,6 +1101,8 @@ async def run_service_with_file(
     temperature: Optional[float] = Form(None),
     top_p: Optional[float] = Form(None),
     organization_id: Optional[str] = Form(None),
+    organization_name: Optional[str] = Form(None, description="Organization display name, exposed at export time as {{organization_name}}"),
+    conversation_name: Optional[str] = Form(None, description="Conversation/session display name, exposed at export time as {{conversation_name}}"),
     context: Optional[str] = Form(None, description="JSON-encoded context data for categorization (tags, metadata)"),
     db: AsyncSession = Depends(get_db),
 ):
@@ -1134,6 +1147,8 @@ async def run_service_with_file(
         temperature=temperature,
         top_p=top_p,
         organization_id=organization_id,
+        organization_name=organization_name,
+        conversation_name=conversation_name,
         db=db,
         context_data=context_data,
     )

--- a/app/migrations/versions/006_add_job_name_metadata.py
+++ b/app/migrations/versions/006_add_job_name_metadata.py
@@ -1,0 +1,31 @@
+"""add_job_name_metadata - Store caller-supplied names on the job
+
+Revision ID: 006
+Revises: 005
+Create Date: 2026-05-20 00:00:00.000000
+
+Two human-readable names captured when the job is created so they can be
+exposed as standard template placeholders at export time:
+  * conversation_name : name of the originating conversation/session
+  * organization_name : name of the organization (companion to organization_id)
+"""
+from typing import Sequence, Union
+
+from alembic import op
+import sqlalchemy as sa
+
+# revision identifiers, used by Alembic.
+revision: str = '006'
+down_revision: Union[str, None] = '005'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    op.add_column('jobs', sa.Column('conversation_name', sa.String(255), nullable=True))
+    op.add_column('jobs', sa.Column('organization_name', sa.String(255), nullable=True))
+
+
+def downgrade() -> None:
+    op.drop_column('jobs', 'organization_name')
+    op.drop_column('jobs', 'conversation_name')

--- a/app/models/job.py
+++ b/app/models/job.py
@@ -19,6 +19,12 @@ class Job(Base):
     # Free-form organization identifier (no FK constraint)
     organization_id = Column(String(100), nullable=True, index=True)
 
+    # Caller-supplied human-readable names. Stored so that export templates
+    # can expose them as standard placeholders ({{conversation_name}},
+    # {{organization_name}}) without depending on caller-side resolution.
+    conversation_name = Column(String(255), nullable=True)
+    organization_name = Column(String(255), nullable=True)
+
     status = Column(String(20), nullable=False, default="queued")
     celery_task_id = Column(String(255), unique=True, nullable=True)
 

--- a/app/schemas/job.py
+++ b/app/schemas/job.py
@@ -154,6 +154,8 @@ class JobResponse(BaseModel):
     progress: Optional[JobProgress] = None
     # Free-form organization identifier (any string up to 100 chars)
     organization_id: Optional[str] = None
+    conversation_name: Optional[str] = None
+    organization_name: Optional[str] = None
 
     # Fallback tracking fields
     fallback_applied: bool = Field(

--- a/app/services/document_service.py
+++ b/app/services/document_service.py
@@ -366,6 +366,20 @@ class DocumentService:
 
         return placeholders
 
+    @staticmethod
+    def _set_run_text(run, new_text: str) -> None:
+        """Assign ``new_text`` to ``run.text`` only if it actually changed.
+
+        Why: python-docx's ``Run.text`` setter calls ``clear_content()`` which
+        removes every child of ``<w:r>`` except ``<w:rPr>`` - including
+        ``<w:drawing>``. Assigning the same value back therefore deletes any
+        embedded image. Runs that carry an inline image have empty ``.text``,
+        so the guard ``new_text != run.text`` skips them entirely and keeps
+        the drawing intact.
+        """
+        if new_text != run.text:
+            run.text = new_text
+
     def substitute_placeholders(self, doc, placeholders: Dict[str, Any]) -> None:
         """
         Replace {{placeholder}} in DOCX paragraphs, tables, headers, footers.
@@ -401,7 +415,7 @@ class DocumentService:
             if "{{output}}" in full_text:
                 # Clear the paragraph
                 for run in para.runs:
-                    run.text = ""
+                    self._set_run_text(run, "")
                 # Insert formatted markdown content after this paragraph
                 return True
             return False
@@ -409,7 +423,7 @@ class DocumentService:
         # First pass: replace simple placeholders
         for para in doc.paragraphs:
             for run in para.runs:
-                run.text = replace_text_simple(run.text)
+                self._set_run_text(run, replace_text_simple(run.text))
 
         # Second pass: find and replace {{output}} with formatted content
         paragraphs_to_process = []
@@ -422,7 +436,7 @@ class DocumentService:
         for idx, para in paragraphs_to_process:
             # Clear the placeholder
             for run in para.runs:
-                run.text = run.text.replace("{{output}}", "")
+                self._set_run_text(run, run.text.replace("{{output}}", ""))
             # Insert markdown as formatted DOCX content
             self._insert_markdown_content(doc, para, output_content)
 
@@ -432,20 +446,20 @@ class DocumentService:
                 for cell in row.cells:
                     for para in cell.paragraphs:
                         for run in para.runs:
-                            run.text = replace_text_simple(run.text)
+                            self._set_run_text(run, replace_text_simple(run.text))
                             # For tables, just use plain text for output
-                            run.text = run.text.replace("{{output}}", output_content)
+                            self._set_run_text(run, run.text.replace("{{output}}", output_content))
 
         # Replace in headers/footers (simple replacement only)
         for section in doc.sections:
             if section.header:
                 for para in section.header.paragraphs:
                     for run in para.runs:
-                        run.text = replace_text_simple(run.text)
+                        self._set_run_text(run, replace_text_simple(run.text))
             if section.footer:
                 for para in section.footer.paragraphs:
                     for run in para.runs:
-                        run.text = replace_text_simple(run.text)
+                        self._set_run_text(run, replace_text_simple(run.text))
 
         # Final pass: clean up any remaining unfilled placeholders
         # Matches {{anything}} or {{anything: with hint}}
@@ -457,24 +471,24 @@ class DocumentService:
 
         for para in doc.paragraphs:
             for run in para.runs:
-                run.text = clean_unfilled(run.text)
+                self._set_run_text(run, clean_unfilled(run.text))
 
         for table in doc.tables:
             for row in table.rows:
                 for cell in row.cells:
                     for para in cell.paragraphs:
                         for run in para.runs:
-                            run.text = clean_unfilled(run.text)
+                            self._set_run_text(run, clean_unfilled(run.text))
 
         for section in doc.sections:
             if section.header:
                 for para in section.header.paragraphs:
                     for run in para.runs:
-                        run.text = clean_unfilled(run.text)
+                        self._set_run_text(run, clean_unfilled(run.text))
             if section.footer:
                 for para in section.footer.paragraphs:
                     for run in para.runs:
-                        run.text = clean_unfilled(run.text)
+                        self._set_run_text(run, clean_unfilled(run.text))
 
     def _insert_markdown_content(self, doc, after_para, markdown_content: str) -> None:
         """

--- a/app/services/document_service.py
+++ b/app/services/document_service.py
@@ -30,7 +30,9 @@ class DocumentService:
         "job_date",
         "service_name",
         "flavor_name",
+        "organization_id",
         "organization_name",
+        "conversation_name",
         "generated_at",
     ]
 
@@ -328,7 +330,9 @@ class DocumentService:
             "job_date": job_date,
             "service_name": job.service.name if job.service else "",
             "flavor_name": job.flavor.name if job.flavor else "",
-            "organization_name": job.organization_id or "",
+            "organization_id": job.organization_id or "",
+            "organization_name": job.organization_name or "",
+            "conversation_name": job.conversation_name or "",
             "generated_at": now.strftime("%Y-%m-%d %H:%M"),
         }
 
@@ -379,6 +383,55 @@ class DocumentService:
         """
         if new_text != run.text:
             run.text = new_text
+
+    def _rescue_split_placeholders(self, para, transform) -> None:
+        """Catch placeholders that Word split across multiple runs.
+
+        Per-run substitution can't match ``{{key}}`` when Word chose to break
+        the string into separate ``<w:r>`` elements (e.g. ``': {{organization_'``
+        / ``'id'`` / ``'}}'``). After the normal per-run pass, this method
+        joins the paragraph text, retries the transform, and - only if the
+        result actually changed - writes the new full text into the first
+        text-bearing run and clears the others.
+
+        Empty runs (typically inline images) are never touched, so embedded
+        drawings survive the rewrite.
+        """
+        runs = para.runs
+        if not runs:
+            return
+        full_text = "".join(run.text for run in runs)
+        if "{{" not in full_text:
+            return
+        new_text = transform(full_text)
+        if new_text == full_text:
+            return
+        target_assigned = False
+        for run in runs:
+            if not run.text:
+                continue
+            if not target_assigned:
+                self._set_run_text(run, new_text)
+                target_assigned = True
+            else:
+                self._set_run_text(run, "")
+        if not target_assigned:
+            self._set_run_text(runs[0], new_text)
+
+    def _iter_all_paragraphs(self, doc):
+        """Yield every paragraph in body, tables, headers and footers."""
+        for para in doc.paragraphs:
+            yield para
+        for table in doc.tables:
+            for row in table.rows:
+                for cell in row.cells:
+                    for para in cell.paragraphs:
+                        yield para
+        for section in doc.sections:
+            for hf in (section.header, section.footer):
+                if hf is not None:
+                    for para in hf.paragraphs:
+                        yield para
 
     def substitute_placeholders(self, doc, placeholders: Dict[str, Any]) -> None:
         """
@@ -461,6 +514,14 @@ class DocumentService:
                     for run in para.runs:
                         self._set_run_text(run, replace_text_simple(run.text))
 
+        # Rescue pass: catch placeholders that Word split across multiple
+        # runs (per-run replacement can't match them). Operates at the
+        # paragraph level and only rewrites a paragraph whose joined text
+        # actually changes - so paragraphs without placeholders, and
+        # placeholders the per-run pass already filled, are left alone.
+        for para in self._iter_all_paragraphs(doc):
+            self._rescue_split_placeholders(para, replace_text_simple)
+
         # Final pass: clean up any remaining unfilled placeholders
         # Matches {{anything}} or {{anything: with hint}}
         import re
@@ -489,6 +550,11 @@ class DocumentService:
                 for para in section.footer.paragraphs:
                     for run in para.runs:
                         self._set_run_text(run, clean_unfilled(run.text))
+
+        # Final rescue: clean any split unfilled placeholders that survive
+        # the per-run cleanup (e.g. '{{' / 'unknown' / '}}').
+        for para in self._iter_all_paragraphs(doc):
+            self._rescue_split_placeholders(para, clean_unfilled)
 
     def _insert_markdown_content(self, doc, after_para, markdown_content: str) -> None:
         """

--- a/app/services/document_template_service.py
+++ b/app/services/document_template_service.py
@@ -14,6 +14,7 @@ from sqlalchemy import select, update, or_, and_
 from fastapi import UploadFile
 
 from app.models.document_template import DocumentTemplate
+from app.services.document_service import DocumentService
 
 logger = logging.getLogger(__name__)
 
@@ -33,16 +34,9 @@ class DocumentTemplateService:
     ]
     DOCX_MAGIC_BYTES = b"PK"  # DOCX is a ZIP file
 
-    # Standard placeholders that are system-provided, not extracted
-    STANDARD_PLACEHOLDERS = [
-        "output",
-        "job_id",
-        "job_date",
-        "service_name",
-        "flavor_name",
-        "organization_name",
-        "generated_at",
-    ]
+    # Standard placeholders that are system-provided, not extracted.
+    # Single source of truth lives in DocumentService.
+    STANDARD_PLACEHOLDERS = DocumentService.STANDARD_PLACEHOLDERS
 
     def __init__(self):
         """Initialize template service."""

--- a/app/services/export_service.py
+++ b/app/services/export_service.py
@@ -675,8 +675,12 @@ class ExportService:
             return job.service.name if job.service else None
         elif name == "flavor_name":
             return job.flavor.name if job.flavor else None
-        elif name == "organization_name":
+        elif name == "organization_id":
             return job.organization_id
+        elif name == "organization_name":
+            return job.organization_name
+        elif name == "conversation_name":
+            return job.conversation_name
         elif name == "generated_at":
             return datetime.now().strftime("%Y-%m-%d %H:%M")
         return None

--- a/app/services/job_service.py
+++ b/app/services/job_service.py
@@ -100,6 +100,8 @@ class JobService:
         flavor_id: UUID,
         celery_task_id: str,
         organization_id: Optional[str] = None,
+        conversation_name: Optional[str] = None,
+        organization_name: Optional[str] = None,
         input_file_name: Optional[str] = None,
         input_preview: Optional[str] = None,
         # Fallback tracking
@@ -122,6 +124,8 @@ class JobService:
             service_id=service_id,
             flavor_id=flavor_id,
             organization_id=organization_id,
+            conversation_name=conversation_name,
+            organization_name=organization_name,
             celery_task_id=celery_task_id,
             status="queued",
             input_file_name=input_file_name,
@@ -189,6 +193,8 @@ class JobService:
             error=job.error,
             progress=progress_obj,
             organization_id=job.organization_id,
+            conversation_name=job.conversation_name,
+            organization_name=job.organization_name,
             # Fallback tracking
             fallback_applied=job.fallback_applied == "true",
             original_flavor_id=job.original_flavor_id,
@@ -324,6 +330,8 @@ class JobService:
                 error=job.error,
                 progress=progress_obj,
                 organization_id=job.organization_id,
+                conversation_name=job.conversation_name,
+                organization_name=job.organization_name,
                 # Fallback tracking
                 fallback_applied=job.fallback_applied == "true",
                 original_flavor_id=job.original_flavor_id,

--- a/frontend/components/jobs/JobMetadata.tsx
+++ b/frontend/components/jobs/JobMetadata.tsx
@@ -135,6 +135,22 @@ export function JobMetadata({ job }: JobMetadataProps) {
             </div>
           )}
 
+          {/* Organization Name (if provided by caller) */}
+          {job.organization_name && (
+            <div className="space-y-1">
+              <span className="text-sm text-muted-foreground">{t('organizationName')}</span>
+              <p className="font-medium">{job.organization_name}</p>
+            </div>
+          )}
+
+          {/* Conversation Name (if provided by caller) */}
+          {job.conversation_name && (
+            <div className="space-y-1">
+              <span className="text-sm text-muted-foreground">{t('conversationName')}</span>
+              <p className="font-medium">{job.conversation_name}</p>
+            </div>
+          )}
+
           {/* Fallback Applied Info */}
           {job.fallback_applied && (
             <>

--- a/frontend/components/jobs/MetadataDisplay.tsx
+++ b/frontend/components/jobs/MetadataDisplay.tsx
@@ -17,7 +17,7 @@ import {
   Globe,
   Hash,
 } from 'lucide-react';
-import { parsePlaceholder } from '@/types/document-template';
+import { parsePlaceholder, STANDARD_PLACEHOLDERS } from '@/types/document-template';
 
 interface MetadataDisplayProps {
   metadata: Record<string, any>;
@@ -28,17 +28,6 @@ interface MetadataDisplayProps {
  * Renders different field types appropriately (strings, arrays, sentiment badges).
  * Skips internal fields (those starting with _).
  */
-// Standard placeholders provided by the system - not extracted metadata
-const STANDARD_PLACEHOLDERS = [
-  'output',
-  'job_id',
-  'job_date',
-  'service_name',
-  'flavor_name',
-  'organization_name',
-  'generated_at',
-];
-
 export function MetadataDisplay({ metadata }: MetadataDisplayProps) {
   const t = useTranslations('metadata');
 
@@ -48,7 +37,7 @@ export function MetadataDisplay({ metadata }: MetadataDisplayProps) {
 
   // Filter out internal fields (starting with _) and standard placeholders
   const displayFields = Object.entries(metadata).filter(
-    ([key]) => !key.startsWith('_') && !STANDARD_PLACEHOLDERS.includes(key)
+    ([key]) => !key.startsWith('_') && !(STANDARD_PLACEHOLDERS as readonly string[]).includes(key)
   );
 
   if (displayFields.length === 0) {

--- a/frontend/messages/en/jobs.json
+++ b/frontend/messages/en/jobs.json
@@ -64,6 +64,8 @@
   "noInput": "No input data available",
   "metadata": "Metadata",
   "organizationId": "Organization ID",
+  "organizationName": "Organization name",
+  "conversationName": "Conversation name",
   "renderedView": "Rendered",
   "rawView": "Raw",
   "phase": {

--- a/frontend/messages/fr/jobs.json
+++ b/frontend/messages/fr/jobs.json
@@ -64,6 +64,8 @@
   "noInput": "Aucune donnee d'entree disponible",
   "metadata": "Metadonnees",
   "organizationId": "ID d'organisation",
+  "organizationName": "Nom d'organisation",
+  "conversationName": "Nom de conversation",
   "renderedView": "Formaté",
   "rawView": "Brut",
   "phase": {

--- a/frontend/types/document-template.ts
+++ b/frontend/types/document-template.ts
@@ -132,7 +132,9 @@ export const STANDARD_PLACEHOLDERS = [
   'job_date',
   'service_name',
   'flavor_name',
+  'organization_id',
   'organization_name',
+  'conversation_name',
   'generated_at',
 ] as const;
 

--- a/frontend/types/job.ts
+++ b/frontend/types/job.ts
@@ -117,6 +117,8 @@ export interface JobResponse {
   error: string | null; // Error message if failed
   progress: JobProgress | null;
   organization_id: string | null; // Free-form string (max 100 chars)
+  conversation_name?: string | null;
+  organization_name?: string | null;
 
   // Fallback tracking fields (populated at job creation)
   fallback_applied?: boolean;

--- a/tests/test_job_ttl.py
+++ b/tests/test_job_ttl.py
@@ -460,6 +460,8 @@ class TestJobServiceTTLResponses:
         mock_job.error = None
         mock_job.progress = None
         mock_job.organization_id = None
+        mock_job.conversation_name = None
+        mock_job.organization_name = None
         mock_job.current_version = 1
         mock_job.last_edited_at = None
         mock_job.fallback_applied = "false"
@@ -511,6 +513,8 @@ class TestJobServiceTTLResponses:
         mock_job.error = None
         mock_job.progress = None
         mock_job.organization_id = None
+        mock_job.conversation_name = None
+        mock_job.organization_name = None
         mock_job.current_version = 1
         mock_job.last_edited_at = None
         mock_job.fallback_applied = "false"

--- a/tests/test_jobs.py
+++ b/tests/test_jobs.py
@@ -1398,6 +1398,8 @@ class TestJobServiceIntegrationTests:
             "percentage": 100.0,
         }
         mock_job.organization_id = None
+        mock_job.conversation_name = None
+        mock_job.organization_name = None
         mock_job.current_version = 1
         mock_job.last_edited_at = None
         # Fallback tracking fields (use the actual model field names)


### PR DESCRIPTION
  - Add conversation_name and organization_name columns on Job
  - Accept both as caller input on /execute (via metadata) and /run (Form fields)
  - Fix: preserve embedded images when Word splits placeholders across runs
