### PR TITLE
Configurable logging system + exception/content logging fixes

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -42,6 +42,41 @@ DEBUG=false
 CORS_ORIGINS=http://localhost:3000,http://localhost:8001
 
 # =============================================================================
+# Logging
+# =============================================================================
+# Level: DEBUG / INFO / WARNING / ERROR (DEBUG=true above forces DEBUG).
+LOG_LEVEL=INFO
+# Output format on stdout: "text" (human readable) or "json" (structured,
+# for log aggregators that scrape container stdout: Loki, ELK, Cloud Logging).
+LOG_FORMAT=text
+# Service label added to JSON logs / Stackdriver entries.
+LOG_NAME=llm-gateway
+#
+# --- Optional sinks (each is disabled until its trigger var is set) ---
+#
+# Rotating file:
+# LOG_FILE=/var/log/llm-gateway/app.log
+# LOG_FILE_LEVEL=INFO
+# LOG_FILE_MAX_BYTES=10485760
+# LOG_FILE_BACKUP_COUNT=5
+#
+# HTTP POST to a centralized collector (records shipped as JSON, non-blocking):
+# LOG_HTTP_URL=https://logs.example.com/ingest
+# LOG_HTTP_METHOD=POST
+# LOG_HTTP_HEADERS={"Authorization": "Bearer <token>"}
+# LOG_HTTP_LEVEL=INFO
+# LOG_HTTP_TIMEOUT=5.0
+#
+# Google Cloud Logging / Stackdriver (requires google-cloud-logging, see requirements.txt):
+# LOG_STACKDRIVER_ENABLED=true
+# LOG_STACKDRIVER_PROJECT=my-gcp-project
+# LOG_STACKDRIVER_LEVEL=INFO
+#
+# Full control: a JSON file passed verbatim to logging.config.dictConfig.
+# When set, all LOG_* vars above are ignored (Winston WINSTON_CONFIG_PATH equivalent).
+# LOGGING_CONFIG_FILE=/app/config/logging.json
+
+# =============================================================================
 # LLM API Retry Configuration
 # =============================================================================
 API_MAX_RETRIES=6

--- a/README.md
+++ b/README.md
@@ -286,6 +286,20 @@ The gateway automatically retries failed LLM API calls (rate limits, timeouts, 5
 | `API_RETRY_MIN_DELAY` | Minimum delay between retries (seconds) | `1`     |
 | `API_RETRY_MAX_DELAY` | Maximum delay between retries (seconds) | `60`    |
 
+### Logging
+
+Logs default to human readable text on stdout at `INFO`. Switch to structured
+JSON and ship logs to a file, an HTTP collector or Google Cloud Logging via
+environment variables.
+
+| Variable       | Description                            | Default       |
+|----------------|----------------------------------------|---------------|
+| `LOG_LEVEL`    | `DEBUG` / `INFO` / `WARNING` / `ERROR` | `INFO`        |
+| `LOG_FORMAT`   | `text` or `json`                       | `text`        |
+| `LOG_HTTP_URL` | Ship records as JSON to a collector    | (unset)       |
+
+See the **[Logging Guide](docs/LOGGING_GUIDE.md)** for every sink and option.
+
 ## API Endpoints
 
 | Endpoint                       | Method | Description          |
@@ -381,6 +395,7 @@ docker compose up -d --scale celery-worker=4
 - **[Model Limits Guide](docs/MODEL_LIMITS_GUIDE.md)** - Token limits configuration
 - **[Flavor Presets Guide](docs/FLAVOR_PRESETS_GUIDE.md)** - Pre-configured settings
 - **[Document Templates Guide](docs/DOCUMENT_TEMPLATES_GUIDE.md)** - DOCX export
+- **[Logging Guide](docs/LOGGING_GUIDE.md)** - Configurable logging and centralized log shipping
 - **[Security Guide](docs/SECURITY.md)** - Credential rotation and security
 
 ## License

--- a/app/__main__.py
+++ b/app/__main__.py
@@ -1,14 +1,11 @@
-import logging
 import os
 
 os.chdir(os.path.dirname(os.path.abspath(__file__)))
 
+from .core.logging_config import setup_logging  # noqa: E402
+
+setup_logging(service="llm-gateway-api")
+
 from .http_server.ingress import start  # noqa: E402
 
-logging.basicConfig(
-    format="%(asctime)s %(name)s %(levelname)s: %(message)s",
-    datefmt="%d/%m/%Y %H:%M:%S",
-)
-logger = logging.getLogger("__llm_gateway__")
-logger.setLevel(logging.INFO)
 start()

--- a/app/api/v1/chat.py
+++ b/app/api/v1/chat.py
@@ -112,7 +112,7 @@ async def sse_generator(
             elif content:
                 yield f"event: token\ndata: {json.dumps({'content': content})}\n\n"
     except Exception as e:
-        logger.error(f"Chat streaming error: {e}")
+        logger.exception(f"Chat streaming error: {e}")
         yield f"event: error\ndata: {json.dumps({'error': 'Streaming error'})}\n\n"
 
 

--- a/app/api/v1/health.py
+++ b/app/api/v1/health.py
@@ -33,7 +33,7 @@ async def check_redis_connection() -> bool:
         loop = asyncio.get_event_loop()
         return await loop.run_in_executor(None, _sync_ping)
     except Exception as e:
-        logger.error(f"Redis connection check failed: {e}")
+        logger.exception(f"Redis connection check failed: {e}")
         return False
 
 

--- a/app/api/v1/huggingface.py
+++ b/app/api/v1/huggingface.py
@@ -41,7 +41,7 @@ async def get_tokenizer_info(repo_path: str) -> HuggingFaceTokenizerResponse:
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Error fetching tokenizer info for {repo_path}: {e}")
+        logger.exception(f"Error fetching tokenizer info for {repo_path}: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"HuggingFace API error: {str(e)}",

--- a/app/api/v1/jobs.py
+++ b/app/api/v1/jobs.py
@@ -204,7 +204,7 @@ async def list_jobs(
             page_size=page_size,
         )
     except Exception as e:
-        logger.error(f"Error listing jobs: {e}")
+        logger.exception(f"Error listing jobs: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"Failed to list jobs: {str(e)}",
@@ -653,7 +653,7 @@ async def websocket_job_status(websocket: WebSocket, job_id: str):
         logger.info(f"WebSocket for job {job_id} cancelled (server shutdown)")
         raise
     except Exception as e:
-        logger.error(f"WebSocket error for job {job_id}: {e}")
+        logger.exception(f"WebSocket error for job {job_id}: {e}")
         try:
             await websocket.close(code=1011)  # Internal error
         except Exception:
@@ -773,7 +773,7 @@ async def websocket_jobs_status(websocket: WebSocket, organization_id: Optional[
                 # Timeout is normal, just continue the loop
                 continue
             except json.JSONDecodeError as e:
-                logger.warning(f"Global WS: failed to parse Redis message: {e}")
+                logger.warning(f"Global WS: failed to parse Redis message: {e}", exc_info=True)
             except WebSocketDisconnect:
                 logger.info("Client disconnected during message processing")
                 return
@@ -784,7 +784,7 @@ async def websocket_jobs_status(websocket: WebSocket, organization_id: Optional[
                     return
                 raise
             except Exception as e:
-                logger.error(f"Global WS: error processing message: {e}")
+                logger.exception(f"Global WS: error processing message: {e}")
 
     except WebSocketDisconnect:
         logger.info("Client disconnected from global jobs WebSocket")
@@ -1189,7 +1189,7 @@ async def export_job_result(
                     flavor.model.provider.api_base_url
                 )
         except Exception as e:
-            logger.warning(f"Could not prepare LLM for JIT extraction: {e}")
+            logger.warning(f"Could not prepare LLM for JIT extraction: {e}", exc_info=True)
 
     # Generate document with JIT extraction
     try:

--- a/app/api/v1/models.py
+++ b/app/api/v1/models.py
@@ -55,7 +55,7 @@ async def create_model(
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Error creating model: {e}")
+        logger.exception(f"Error creating model: {e}")
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=f"Failed to create model: {str(e)}"
@@ -101,7 +101,7 @@ async def list_models(
             page_size=page_size
         )
     except Exception as e:
-        logger.error(f"Error listing models: {e}")
+        logger.exception(f"Error listing models: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"Failed to list models: {str(e)}"
@@ -190,7 +190,7 @@ async def update_model(
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Error updating model: {e}")
+        logger.exception(f"Error updating model: {e}")
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=f"Failed to update model: {str(e)}"
@@ -229,7 +229,7 @@ async def patch_model(
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Error patching model: {e}")
+        logger.exception(f"Error patching model: {e}")
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=f"Failed to update model: {str(e)}"
@@ -260,7 +260,7 @@ async def delete_model(
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Error deleting model: {e}")
+        logger.exception(f"Error deleting model: {e}")
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=f"Failed to delete model: {str(e)}"
@@ -295,7 +295,7 @@ async def verify_provider_models(
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Error verifying models: {e}")
+        logger.exception(f"Error verifying models: {e}")
         raise HTTPException(
             status_code=status.HTTP_503_SERVICE_UNAVAILABLE,
             detail=f"Model verification failed: {str(e)}"
@@ -333,7 +333,7 @@ async def list_all_models(
             page_size=page_size,
         )
     except Exception as e:
-        logger.error(f"Error listing all models: {e}")
+        logger.exception(f"Error listing all models: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"Failed to list models: {str(e)}",
@@ -367,7 +367,7 @@ async def create_model_top_level(
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Error creating model: {e}")
+        logger.exception(f"Error creating model: {e}")
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=f"Failed to create model: {str(e)}",
@@ -391,7 +391,7 @@ async def delete_model_top_level(
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Error deleting model: {e}")
+        logger.exception(f"Error deleting model: {e}")
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=f"Failed to delete model: {str(e)}",

--- a/app/api/v1/providers.py
+++ b/app/api/v1/providers.py
@@ -49,7 +49,7 @@ async def create_provider(
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Error creating provider: {e}")
+        logger.exception(f"Error creating provider: {e}")
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail={
@@ -100,7 +100,7 @@ async def list_providers(
             page_size=page_size
         )
     except Exception as e:
-        logger.error(f"Error listing providers: {e}")
+        logger.exception(f"Error listing providers: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail={
@@ -162,7 +162,7 @@ async def get_provider(
             }
         )
     except Exception as e:
-        logger.error(f"Error getting provider: {e}")
+        logger.exception(f"Error getting provider: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail={
@@ -232,7 +232,7 @@ async def update_provider(
             }
         )
     except Exception as e:
-        logger.error(f"Error updating provider: {e}")
+        logger.exception(f"Error updating provider: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail={
@@ -295,7 +295,7 @@ async def delete_provider(
             }
         )
     except Exception as e:
-        logger.error(f"Error deleting provider: {e}")
+        logger.exception(f"Error deleting provider: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail={
@@ -356,7 +356,7 @@ async def discover_models(
             detail=str(e)
         )
     except Exception as e:
-        logger.error(f"Discovery failed for provider {provider_id}: {e}")
+        logger.exception(f"Discovery failed for provider {provider_id}: {e}")
         raise HTTPException(
             status_code=500,
             detail=f"Discovery failed: {str(e)}"

--- a/app/api/v1/services.py
+++ b/app/api/v1/services.py
@@ -130,7 +130,7 @@ async def _validate_context(
         manager = TokenizerManager.get_instance()
         input_tokens = manager.count_tokens(flavor.model, content)
     except Exception as e:
-        logger.warning(f"Tokenizer count failed, using estimate: {e}")
+        logger.warning(f"Tokenizer count failed, using estimate: {e}", exc_info=True)
         input_tokens = len(content) // 4  # Rough estimate
 
     # Calculate available tokens using direct model limits
@@ -194,7 +194,7 @@ async def create_service(
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Error creating service: {e}")
+        logger.exception(f"Error creating service: {e}")
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=f"Failed to create service: {str(e)}"
@@ -243,7 +243,7 @@ async def list_services(
             page_size=page_size
         )
     except Exception as e:
-        logger.error(f"Error listing services: {e}")
+        logger.exception(f"Error listing services: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"Failed to list services: {str(e)}"
@@ -302,7 +302,7 @@ async def update_service(
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Error updating service: {e}")
+        logger.exception(f"Error updating service: {e}")
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=f"Failed to update service: {str(e)}"
@@ -330,7 +330,7 @@ async def delete_service(
     except HTTPException:
         raise
     except Exception as e:
-        logger.error(f"Error deleting service: {e}")
+        logger.exception(f"Error deleting service: {e}")
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=f"Failed to delete service: {str(e)}"
@@ -446,7 +446,7 @@ async def add_flavor_to_service(
         return flavor
     except Exception as e:
         await db.rollback()
-        logger.error(f"Error creating flavor: {e}")
+        logger.exception(f"Error creating flavor: {e}")
         raise HTTPException(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=f"Failed to create flavor: {str(e)}"
@@ -1253,7 +1253,7 @@ async def validate_execution(
         manager = TokenizerManager.get_instance()
         input_tokens = manager.count_tokens(flavor.model, content)
     except Exception as e:
-        logger.warning(f"Tokenizer count failed: {e}")
+        logger.warning(f"Tokenizer count failed: {e}", exc_info=True)
         input_tokens = len(content) // 4
 
     # Iterative mode: always valid, but warn if reduce/extraction/categorization may exceed context
@@ -1298,7 +1298,7 @@ async def validate_execution(
         if flavor.prompt_user_content:
             prompt_tokens += manager.count_tokens(flavor.model, flavor.prompt_user_content)
     except Exception as e:
-        logger.warning(f"Tokenizer count failed for prompts: {e}")
+        logger.warning(f"Tokenizer count failed for prompts: {e}", exc_info=True)
         prompt_tokens = 500
 
     # Real input tokens = content + prompts

--- a/app/api/v1/tokenizers.py
+++ b/app/api/v1/tokenizers.py
@@ -116,7 +116,7 @@ async def preload_tokenizer(
             message=preload_result.message,
         )
     except Exception as e:
-        logger.error(f"Failed to preload tokenizer for model {model_id}: {e}")
+        logger.exception(f"Failed to preload tokenizer for model {model_id}: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"Failed to load tokenizer: {str(e)}",
@@ -184,7 +184,7 @@ async def preload_tokenizer_by_repo(
             message="Tokenizer downloaded and persisted",
         )
     except Exception as e:
-        logger.error(f"Failed to preload tokenizer from repo {repo}: {e}")
+        logger.exception(f"Failed to preload tokenizer from repo {repo}: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"Failed to load tokenizer: {str(e)}",
@@ -221,7 +221,7 @@ async def delete_tokenizer(tokenizer_id: str) -> TokenizerDeleteResponse:
             detail="Tokenizer not found",
         )
     except Exception as e:
-        logger.error(f"Failed to delete tokenizer {tokenizer_id}: {e}")
+        logger.exception(f"Failed to delete tokenizer {tokenizer_id}: {e}")
         raise HTTPException(
             status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
             detail=f"Failed to delete tokenizer: {str(e)}",

--- a/app/backends/backend.py
+++ b/app/backends/backend.py
@@ -3,7 +3,6 @@ import os
 os.environ['TOKENIZERS_PARALLELISM'] = 'false'
 
 import logging
-from app.core.config import settings
 from .chunking import Chunker
 
 # Logging is configured centrally at process startup (app/core/logging_config.py).
@@ -57,7 +56,7 @@ class LLMBackend:
             return True
         
         except Exception as e:
-            self.logger.error(f"Error setting up backend: {e}")
+            self.logger.exception(f"Error setting up backend: {e}")
             raise e
 
     def loadPrompt(self):
@@ -120,7 +119,7 @@ class LLMBackend:
                 self.logger.info(f"Loaded tiktoken encoding: {tokenizer_name}")
                 return TiktokenWrapper(encoding, tokenizer_name)
             except Exception as e:
-                self.logger.error(f"Failed to load tiktoken {tokenizer_name}: {e}")
+                self.logger.exception(f"Failed to load tiktoken {tokenizer_name}: {e}")
                 raise
 
         # For HuggingFace tokenizers, try TokenizerManager first
@@ -143,7 +142,7 @@ class LLMBackend:
             return wrapper
 
         except Exception as e:
-            self.logger.warning(f"TokenizerManager failed for {tokenizer_name}: {e}, falling back to direct load")
+            self.logger.warning(f"TokenizerManager failed for {tokenizer_name}: {e}, falling back to direct load", exc_info=True)
 
             # Fallback to direct AutoTokenizer loading
             try:
@@ -152,5 +151,5 @@ class LLMBackend:
                 self.logger.info(f"Loaded tokenizer directly: {tokenizer_name}")
                 return tokenizer
             except Exception as e2:
-                self.logger.error(f"Failed to load tokenizer {tokenizer_name}: {e2}")
+                self.logger.exception(f"Failed to load tokenizer {tokenizer_name}: {e2}")
                 raise

--- a/app/backends/backend.py
+++ b/app/backends/backend.py
@@ -6,11 +6,7 @@ import logging
 from app.core.config import settings
 from .chunking import Chunker
 
-# Configure logging format and level
-logging.basicConfig(
-    format="%(asctime)s %(name)s %(levelname)s: %(message)s",
-    datefmt="%d/%m/%Y %H:%M:%S",
-)
+# Logging is configured centrally at process startup (app/core/logging_config.py).
 
 class LLMBackend:
     """
@@ -28,7 +24,6 @@ class LLMBackend:
             Exception: If any errors occur during setup.
         """
         self.logger = logging.getLogger("backend")
-        self.logger.setLevel(logging.DEBUG if settings.debug else logging.INFO)
         self.logger.info(f"Setting up backend with params: {task_data['backendParams']} for task: {task_data['task_id']}")
 
         # Store task_data reference for prompt loading

--- a/app/backends/batch_manager.py
+++ b/app/backends/batch_manager.py
@@ -256,7 +256,7 @@ class BatchManager:
                 response = result
                 usage = {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}
         except Exception as e:
-            self.logger.error(f"Error in single pass: {e}")
+            self.logger.exception(f"Error in single pass: {e}")
             raise
 
         # Handle None response
@@ -329,7 +329,7 @@ class BatchManager:
                 response = result
                 usage = {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}
         except Exception as e:
-            self.logger.error(f"Error publishing: {e}")
+            self.logger.exception(f"Error publishing: {e}")
             raise
 
         # Handle None response
@@ -394,7 +394,7 @@ class BatchManager:
                 self.logger.warning(
                     f"Skipping oversized turn {i}: {turn_token_count} tokens "
                     f"(max: {available_context - self.prompt_token_count}). "
-                    f"Turn preview: {turn[:100]}..."
+                    f"Turn length: {len(turn)} chars"
                 )
                 i += 1
                 continue
@@ -620,7 +620,7 @@ class BatchManager:
                 response = result
                 usage = {"prompt_tokens": 0, "completion_tokens": 0, "total_tokens": 0}
         except Exception as e:
-            self.logger.error(f"Error in reduce: {e}")
+            self.logger.exception(f"Error in reduce: {e}")
             raise
 
         if response is None:

--- a/app/backends/llm_inference.py
+++ b/app/backends/llm_inference.py
@@ -188,7 +188,7 @@ class LLMInferenceEngine(LLMBackend):
             )
 
             logger.info(f"Extraction response length: {output_chars} chars")
-            logger.debug(f"Extraction response preview: {response[:200] if response else 'EMPTY'}")
+            logger.debug(f"Extraction response preview: ({output_chars} chars)")
 
             # Handle empty response
             if not response or not response.strip():
@@ -202,10 +202,10 @@ class LLMInferenceEngine(LLMBackend):
             return metadata
 
         except json.JSONDecodeError as e:
-            logger.error(f"Failed to parse extraction response as JSON: {e}")
+            logger.exception(f"Failed to parse extraction response as JSON: {e}")
             return {"_extraction_error": f"JSON parse error: {str(e)}"}
         except Exception as e:
-            logger.error(f"Metadata extraction failed: {e}")
+            logger.exception(f"Metadata extraction failed: {e}")
             return {"_extraction_error": str(e)}
 
     def _parse_json_response(self, response: str) -> dict:
@@ -221,7 +221,7 @@ class LLMInferenceEngine(LLMBackend):
         Raises:
             json.JSONDecodeError: If response is not valid JSON
         """
-        logger.debug(f"Raw response to parse: {response[:500] if response else 'EMPTY'}")
+        logger.debug(f"Raw response to parse: ({len(response) if response else 0} chars)")
         text = response.strip()
 
         # Remove markdown code blocks if present
@@ -238,9 +238,9 @@ class LLMInferenceEngine(LLMBackend):
         json_match = re.search(r'\{[\s\S]*\}', text)
         if json_match:
             text = json_match.group()
-            logger.debug(f"Extracted JSON: {text[:200]}")
+            logger.debug(f"Extracted JSON: ({len(text)} chars)")
         else:
-            logger.warning(f"No JSON object found in response: {text[:200]}")
+            logger.warning(f"No JSON object found in response: ({len(text)} chars)")
 
         return json.loads(text)
 
@@ -309,7 +309,7 @@ class LLMInferenceEngine(LLMBackend):
             elif "{{context[tags]}}" in categorization_prompt:
                 categorization_prompt = categorization_prompt.replace("{{context[tags]}}", tags_json)
 
-            logger.debug(f"Categorization prompt (first 500 chars): {categorization_prompt[:500]}")
+            logger.debug(f"Categorization prompt (first 500 chars): ({len(categorization_prompt)} chars)")
 
             # Call LLM for categorization using the batch manager's adapter (sync)
             from datetime import datetime
@@ -331,7 +331,7 @@ class LLMInferenceEngine(LLMBackend):
             )
 
             logger.info(f"Categorization response length: {output_chars} chars")
-            logger.debug(f"Categorization response preview: {response[:200] if response else 'EMPTY'}")
+            logger.debug(f"Categorization response preview: ({output_chars} chars)")
 
             # Handle empty response
             if not response or not response.strip():
@@ -345,8 +345,8 @@ class LLMInferenceEngine(LLMBackend):
             return result
 
         except json.JSONDecodeError as e:
-            logger.error(f"Failed to parse categorization response as JSON: {e}")
+            logger.exception(f"Failed to parse categorization response as JSON: {e}")
             return {"_categorization_error": f"JSON parse error: {str(e)}"}
         except Exception as e:
-            logger.error(f"Document categorization failed: {e}")
+            logger.exception(f"Document categorization failed: {e}")
             return {"_categorization_error": str(e)}

--- a/app/backends/openai_adapter.py
+++ b/app/backends/openai_adapter.py
@@ -125,10 +125,10 @@ class OpenAIAdapter:
                     return response_content, usage
                 return response_content
             except BadRequestError as e:
-                self.logger.error(f"BadRequestError from API: {e.message}")
-                self.logger.error(f"Request params: model={self.modelName}, temp={temperature or self.temperature}, "
+                self.logger.exception(f"BadRequestError from API: {e.message}")
+                self.logger.exception(f"Request params: model={self.modelName}, temp={temperature or self.temperature}, "
                                 f"top_p={top_p or self.top_p}, max_tokens={max_tokens or self.maxGenerationLength}")
-                self.logger.error(f"Content length: {len(content)} chars")
+                self.logger.exception(f"Content length: {len(content)} chars")
                 raise
 
         for attempt in Retrying(**self._get_retry_decorator()):
@@ -183,10 +183,10 @@ class OpenAIAdapter:
                     return response_content, usage
                 return response_content
             except BadRequestError as e:
-                self.logger.error(f"BadRequestError from API: {e.message}")
-                self.logger.error(f"Request params: model={self.modelName}, temp={temperature or self.temperature}, "
+                self.logger.exception(f"BadRequestError from API: {e.message}")
+                self.logger.exception(f"Request params: model={self.modelName}, temp={temperature or self.temperature}, "
                                 f"top_p={top_p or self.top_p}, max_tokens={max_tokens or self.maxGenerationLength}")
-                self.logger.error(f"Content length: {len(content)} chars")
+                self.logger.exception(f"Content length: {len(content)} chars")
                 raise
 
         async for attempt in AsyncRetrying(**self._get_retry_decorator()):

--- a/app/core/config.py
+++ b/app/core/config.py
@@ -33,6 +33,29 @@ class Settings(BaseSettings):
     app_description: str = "Gateway for LLM service management"
     docs_url: str = "/docs"
 
+    # Logging
+    # Full override: path to a JSON file passed to logging.config.dictConfig.
+    # When set, every LOG_* knob below is ignored (Winston WINSTON_CONFIG_PATH equivalent).
+    logging_config_file: str = ""
+    log_level: str = "INFO"          # DEBUG / INFO / WARNING / ERROR (DEBUG=true forces DEBUG)
+    log_format: str = "text"         # "text" or "json"
+    log_name: str = "llm-gateway"    # service label injected into JSON / Stackdriver logs
+    # Rotating file sink (disabled unless LOG_FILE is set)
+    log_file: str = ""
+    log_file_level: str = ""         # defaults to log_level when empty
+    log_file_max_bytes: int = 10485760  # 10 MiB
+    log_file_backup_count: int = 5
+    # HTTP POST sink (disabled unless LOG_HTTP_URL is set)
+    log_http_url: str = ""
+    log_http_method: str = "POST"
+    log_http_headers: str = ""       # JSON object string, e.g. {"Authorization": "Bearer ..."}
+    log_http_level: str = ""         # defaults to log_level when empty
+    log_http_timeout: float = 5.0
+    # Google Cloud Logging / Stackdriver sink (needs the google-cloud-logging package)
+    log_stackdriver_enabled: bool = False
+    log_stackdriver_project: str = ""   # GCP project id; auto-detected when empty
+    log_stackdriver_level: str = ""     # defaults to log_level when empty
+
     # Security
     encryption_key: str
 

--- a/app/core/database.py
+++ b/app/core/database.py
@@ -95,5 +95,5 @@ async def check_db_connection() -> bool:
             await conn.execute(text("SELECT 1"))
         return True
     except Exception as e:
-        logger.error(f"Database connection check failed: {e}")
+        logger.exception(f"Database connection check failed: {e}")
         return False

--- a/app/core/logging_config.py
+++ b/app/core/logging_config.py
@@ -1,0 +1,291 @@
+#!/usr/bin/env python3
+"""Centralized, configurable logging for LLM Gateway.
+
+This mirrors the configurability of the LinTO Studio API (which uses Winston):
+selectable "transports" (console, rotating file, HTTP POST, Google Cloud
+Logging / Stackdriver), per-sink levels, and text-or-JSON formatting, all driven
+by environment variables.
+
+Two ways to configure, in order of precedence:
+
+1. ``LOGGING_CONFIG_FILE`` - path to a JSON file passed verbatim to
+   ``logging.config.dictConfig`` (the Winston ``WINSTON_CONFIG_PATH`` equivalent).
+   Full control; the env vars below are ignored when this is set.
+
+2. Environment variables (the common case):
+   - ``LOG_LEVEL``        text level, e.g. INFO / DEBUG (DEBUG forced when DEBUG=true)
+   - ``LOG_FORMAT``       ``text`` (default) or ``json``
+   - ``LOG_NAME``         service label injected into JSON logs (default: llm-gateway)
+   - ``LOG_FILE``         path -> enables a rotating file sink
+   - ``LOG_HTTP_URL``     URL -> ships every record as JSON via HTTP POST
+   - ``LOG_STACKDRIVER_ENABLED`` -> ships to Google Cloud Logging
+   See ``app/core/config.py`` and ``.env.example`` for every knob.
+
+The HTTP sink runs behind a background queue so the network round-trip never
+blocks the request/worker thread. Logging never raises into application code:
+sink errors are swallowed.
+"""
+from __future__ import annotations
+
+import atexit
+import json
+import logging
+import logging.config
+import logging.handlers
+import queue
+import sys
+import urllib.request
+from datetime import datetime
+from typing import Optional
+
+# python-json-logger moved JsonFormatter between 2.x and 3.x; support both.
+try:  # python-json-logger >= 3.0
+    from pythonjsonlogger.json import JsonFormatter
+except ImportError:  # pragma: no cover - older releases
+    from pythonjsonlogger.jsonlogger import JsonFormatter
+
+
+# Kept identical to the previous hardcoded format for backward compatibility.
+DEFAULT_TEXT_FORMAT = "%(asctime)s %(name)s %(levelname)s: %(message)s"
+DEFAULT_DATE_FORMAT = "%d/%m/%Y %H:%M:%S"
+# JSON logs carry ISO-8601 timestamps with millisecond precision (see ISOJsonFormatter).
+JSON_FIELD_FORMAT = "%(asctime)s %(levelname)s %(name)s %(service)s %(message)s"
+
+
+class ISOJsonFormatter(JsonFormatter):
+    """JSON formatter with ISO-8601 timestamps at millisecond precision.
+
+    strftime-based datefmt cannot emit sub-second precision, which matters for
+    ordering events in a centralized log store, so formatTime is overridden to
+    produce e.g. ``2026-06-16T20:02:43.123+02:00`` (local tz offset included).
+    """
+
+    def formatTime(self, record, datefmt=None):
+        dt = datetime.fromtimestamp(record.created).astimezone()
+        return dt.isoformat(timespec="milliseconds")
+
+# Module state so reconfiguration (e.g. Celery forks) is idempotent and the
+# background HTTP listener thread is not leaked.
+_listener: Optional[logging.handlers.QueueListener] = None
+_configured = False
+_atexit_registered = False
+
+
+def _safe_stop_listener() -> None:
+    """Stop the current HTTP queue listener once, tolerating repeat calls.
+
+    ``QueueListener.stop()`` raises if called twice (it nulls its thread), which
+    happens when a reconfigure already stopped it and atexit fires afterwards.
+    """
+    global _listener
+    if _listener is not None and getattr(_listener, "_thread", None) is not None:
+        try:
+            _listener.stop()
+        except Exception:
+            pass
+
+
+class ServiceFilter(logging.Filter):
+    """Attach a static ``service`` attribute to every record.
+
+    Handler-level filter (not logger-level) so it also runs for records that
+    propagate up from child loggers. Needed because the JSON format references
+    ``%(service)s``.
+    """
+
+    def __init__(self, service: str):
+        super().__init__()
+        self.service = service
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        record.service = self.service
+        return True
+
+
+class HTTPJSONHandler(logging.Handler):
+    """Ship each log record as a JSON document via HTTP POST.
+
+    Meant to sit behind a :class:`~logging.handlers.QueueListener` so the
+    network round-trip happens on a background thread. Network/serialization
+    errors are routed through ``handleError`` and never propagate to the caller.
+    """
+
+    def __init__(self, url: str, method: str = "POST",
+                 headers: Optional[dict] = None, timeout: float = 5.0):
+        super().__init__()
+        self.url = url
+        self.method = (method or "POST").upper()
+        self.timeout = timeout
+        self.headers = {"Content-Type": "application/json"}
+        if headers:
+            self.headers.update(headers)
+
+    def emit(self, record: logging.LogRecord) -> None:
+        try:
+            body = self.format(record).encode("utf-8")
+            request = urllib.request.Request(
+                self.url, data=body, method=self.method, headers=self.headers
+            )
+            with urllib.request.urlopen(request, timeout=self.timeout):
+                pass
+        except Exception:  # logging must never crash the app
+            self.handleError(record)
+
+
+def _name_to_level(value, default: int) -> int:
+    """Resolve a textual level (``"DEBUG"``) to its int, falling back safely."""
+    if not value:
+        return default
+    level = logging.getLevelName(str(value).upper())
+    return level if isinstance(level, int) else default
+
+
+def _build_formatter(fmt: str) -> logging.Formatter:
+    if (fmt or "text").lower() == "json":
+        return ISOJsonFormatter(
+            JSON_FIELD_FORMAT,
+            rename_fields={
+                "asctime": "timestamp",
+                "levelname": "level",
+                "name": "logger",
+            },
+        )
+    return logging.Formatter(DEFAULT_TEXT_FORMAT, datefmt=DEFAULT_DATE_FORMAT)
+
+
+def _parse_headers(raw: str) -> dict:
+    if not raw:
+        return {}
+    try:
+        headers = json.loads(raw)
+        if isinstance(headers, dict):
+            return headers
+    except (ValueError, TypeError):
+        pass
+    logging.getLogger(__name__).warning(
+        "LOG_HTTP_HEADERS is not a valid JSON object; ignoring it."
+    )
+    return {}
+
+
+def _build_stackdriver_handler(settings) -> Optional[logging.Handler]:
+    """Build a Google Cloud Logging handler if the optional dep is installed."""
+    try:
+        import google.cloud.logging
+        from google.cloud.logging_v2.handlers import CloudLoggingHandler
+    except ImportError:
+        logging.getLogger(__name__).warning(
+            "LOG_STACKDRIVER_ENABLED is set but google-cloud-logging is not "
+            "installed; skipping the Stackdriver sink. "
+            "Install it with: pip install google-cloud-logging"
+        )
+        return None
+    client_kwargs = {}
+    if settings.log_stackdriver_project:
+        client_kwargs["project"] = settings.log_stackdriver_project
+    client = google.cloud.logging.Client(**client_kwargs)
+    return CloudLoggingHandler(client, name=settings.log_name)
+
+
+def setup_logging(service: Optional[str] = None, force: bool = False) -> None:
+    """Configure root logging from settings. Idempotent unless ``force=True``.
+
+    Args:
+        service: service label for JSON logs / Stackdriver. Defaults to
+            ``LOG_NAME``. Useful to distinguish API vs worker processes.
+        force: rebuild handlers even if logging was already configured (used
+            after a Celery worker fork, where the listener thread is not
+            inherited).
+    """
+    global _configured, _listener, _atexit_registered
+
+    if _configured and not force:
+        return
+
+    # Late import: logging_config must be importable before settings exist.
+    from app.core.config import settings
+
+    # Option 1: full external dictConfig override (Winston WINSTON_CONFIG_PATH).
+    if settings.logging_config_file:
+        with open(settings.logging_config_file, "r", encoding="utf-8") as handle:
+            logging.config.dictConfig(json.load(handle))
+        _configured = True
+        return
+
+    service_name = service or settings.log_name
+    root_level = (
+        logging.DEBUG if settings.debug
+        else _name_to_level(settings.log_level, logging.INFO)
+    )
+    formatter = _build_formatter(settings.log_format)
+    service_filter = ServiceFilter(service_name)
+
+    root = logging.getLogger()
+
+    # Reset so repeated calls / re-imports do not stack duplicate handlers.
+    for handler in list(root.handlers):
+        root.removeHandler(handler)
+    _safe_stop_listener()
+    _listener = None
+
+    root.setLevel(root_level)
+
+    direct_handlers: list[logging.Handler] = []
+
+    # --- console (always on, stdout) -------------------------------------
+    console = logging.StreamHandler(sys.stdout)
+    console.setLevel(root_level)
+    direct_handlers.append(console)
+
+    # --- rotating file ---------------------------------------------------
+    if settings.log_file:
+        file_handler = logging.handlers.RotatingFileHandler(
+            settings.log_file,
+            maxBytes=settings.log_file_max_bytes,
+            backupCount=settings.log_file_backup_count,
+            encoding="utf-8",
+        )
+        file_handler.setLevel(_name_to_level(settings.log_file_level, root_level))
+        direct_handlers.append(file_handler)
+
+    # --- Google Cloud Logging / Stackdriver ------------------------------
+    if settings.log_stackdriver_enabled:
+        sd_handler = _build_stackdriver_handler(settings)
+        if sd_handler is not None:
+            sd_handler.setLevel(
+                _name_to_level(settings.log_stackdriver_level, root_level)
+            )
+            direct_handlers.append(sd_handler)
+
+    for handler in direct_handlers:
+        handler.setFormatter(formatter)
+        handler.addFilter(service_filter)
+        root.addHandler(handler)
+
+    # --- HTTP POST (non-blocking, behind a background queue listener) ----
+    if settings.log_http_url:
+        http_handler = HTTPJSONHandler(
+            settings.log_http_url,
+            method=settings.log_http_method,
+            headers=_parse_headers(settings.log_http_headers),
+            timeout=settings.log_http_timeout,
+        )
+        # The HTTP sink always ships JSON regardless of the console format.
+        http_handler.setFormatter(_build_formatter("json"))
+        http_handler.setLevel(_name_to_level(settings.log_http_level, root_level))
+
+        log_queue: queue.SimpleQueue = queue.SimpleQueue()
+        queue_handler = logging.handlers.QueueHandler(log_queue)
+        queue_handler.addFilter(service_filter)
+        root.addHandler(queue_handler)
+
+        _listener = logging.handlers.QueueListener(
+            log_queue, http_handler, respect_handler_level=True
+        )
+        _listener.start()
+        if not _atexit_registered:
+            # Single handler that flushes whatever listener is current at exit.
+            atexit.register(_safe_stop_listener)
+            _atexit_registered = True
+
+    _configured = True

--- a/app/http_server/celery_app.py
+++ b/app/http_server/celery_app.py
@@ -120,19 +120,20 @@ def _run_with_failover(celery_task, task_data, failover_depth: int):
 
         if failoverable_error is None:
             # Not a failoverable error - propagate original
-            logger.error(f"Non-failoverable error in task: {str(e)}")
+            logger.exception(f"Non-failoverable error in task: {str(e)}")
             raise
 
         # Check if failover is enabled and configured for this error type
         if not _should_failover(failover_config, failoverable_error, failover_depth, max_depth):
-            logger.error(f"Failoverable error but no failover available: {str(e)}")
+            logger.exception(f"Failoverable error but no failover available: {str(e)}")
             raise failoverable_error from e
 
         # Attempt failover
         failover_flavor_id = failover_config.get("failover_flavor_id")
         logger.warning(
             f"Failover triggered: {failoverable_error.failover_reason} at depth {failover_depth}. "
-            f"Switching to flavor {failover_flavor_id}"
+            f"Switching to flavor {failover_flavor_id}",
+            exc_info=True
         )
 
         # Update Celery state to indicate failover
@@ -149,7 +150,7 @@ def _run_with_failover(celery_task, task_data, failover_depth: int):
         # Get new task_data for the failover flavor
         new_task_data = _get_failover_task_data(task_data, failover_flavor_id)
         if new_task_data is None:
-            logger.error(f"Failed to get task data for failover flavor {failover_flavor_id}")
+            logger.exception(f"Failed to get task data for failover flavor {failover_flavor_id}")
             raise failoverable_error from e
 
         # Recursively run with failover flavor
@@ -316,7 +317,7 @@ def _get_failover_task_data(original_task_data: dict, failover_flavor_id: str) -
             session.close()
 
     except Exception as e:
-        logger.error(f"Error building failover task_data: {e}")
+        logger.exception(f"Error building failover task_data: {e}")
         return None
 
 # Set publish tasked status to QUEUED
@@ -391,7 +392,7 @@ def cleanup_expired_jobs_sync() -> dict:
         return {'deleted_count': result}
     except Exception as e:
         session.rollback()
-        logger.error(f"Error cleaning up expired jobs: {e}")
+        logger.exception(f"Error cleaning up expired jobs: {e}")
         raise
     finally:
         session.close()
@@ -448,7 +449,7 @@ def _publish_job_update(job_id: str, organization_id: str, status: str, progress
         redis_client.publish("job_updates:global", message)
         logger.debug(f"Published job update: job_id={job_id}, status={status}")
     except Exception as e:
-        logger.warning(f"Failed to publish job update to Redis: {e}")
+        logger.warning(f"Failed to publish job update to Redis: {e}", exc_info=True)
 
 def _update_job_status_sync(celery_task_id: str, status: str, result=None, error=None, progress=None):
     """Synchronously update job status in PostgreSQL (for Celery signals)."""
@@ -494,7 +495,7 @@ def _update_job_status_sync(celery_task_id: str, status: str, result=None, error
         finally:
             session.close()
     except Exception as e:
-        logger.error(f"Failed to update job status: {e}")
+        logger.exception(f"Failed to update job status: {e}")
 
 
 # Celery signal handlers for job status synchronization

--- a/app/http_server/celery_app.py
+++ b/app/http_server/celery_app.py
@@ -6,28 +6,40 @@ from celery.app import trace
 from app.core.config import settings
 from app.backends.llm_inference import LLMInferenceEngine
 import redis
-from celery.signals import after_task_publish, task_prerun, task_postrun, task_failure
+from celery.signals import (
+    after_task_publish, task_prerun, task_postrun, task_failure,
+    setup_logging as celery_setup_logging, worker_process_init,
+)
 import time
 import asyncio
 from datetime import datetime
+from app.core.logging_config import setup_logging
 
 # Edit the celery logs format
 trace.LOG_SUCCESS = """\
 Task %(name)s[%(id)s] succeeded in %(runtime)ss\
 """
 
-# Logging Setup
-logging.basicConfig(
-    format="%(asctime)s %(name)s %(levelname)s: %(message)s",
-    datefmt="%d/%m/%Y %H:%M:%S",
-)
 logger = logging.getLogger("celery_worker")
-logger.setLevel(logging.DEBUG if settings.debug else logging.INFO)
+
+
+# Logging Setup - configured centrally (see app/core/logging_config.py).
+# Connecting setup_logging stops Celery from installing its own root logging,
+# so our configurable sinks apply to the worker. worker_process_init rebuilds
+# the handlers inside each forked child (the HTTP queue listener thread is not
+# inherited across fork).
+@celery_setup_logging.connect
+def _configure_celery_logging(**kwargs):
+    setup_logging(service="llm-gateway-worker")
+
+
+@worker_process_init.connect
+def _configure_worker_process_logging(**kwargs):
+    setup_logging(service="llm-gateway-worker", force=True)
+
 
 # Celery App Setup
 celery_app = Celery("tasks")
-celery_app.conf.worker_log_format = "%(asctime)s %(name)s %(levelname)s: %(message)s"
-celery_app.conf.worker_task_log_format = "%(asctime)s %(name)s %(levelname)s: %(message)s"
 
 # Configure the broker and backend from environment variables with defaults
 parsed_url = urlparse(settings.services_broker)

--- a/app/http_server/ingress.py
+++ b/app/http_server/ingress.py
@@ -32,13 +32,11 @@ from app.services.model_service import model_service
 from app.services.provider_service import provider_service
 from app.services.job_service import job_service
 
-# Logging Setup
-logging.basicConfig(
-    format="%(asctime)s %(name)s %(levelname)s: %(message)s",
-    datefmt="%d/%m/%Y %H:%M:%S",
-)
+# Logging Setup - configured centrally (see app/core/logging_config.py).
+# Runs at import time so each uvicorn worker process configures its own sinks.
+from app.core.logging_config import setup_logging
+setup_logging(service="llm-gateway-api")
 logger = logging.getLogger("http_server")
-logger.setLevel(logging.DEBUG if pydantic_settings.debug else logging.INFO)
 
 # Shutdown event for clean task cancellation during hot-reload
 shutdown_event = asyncio.Event()
@@ -294,43 +292,18 @@ async def periodic_orphan_monitor():
 def start():
     """Start the FastAPI application."""
     logger.info("Starting FastAPI application...")
+    # log_config=None: do not let uvicorn reconfigure logging. Its loggers
+    # (uvicorn, uvicorn.error, uvicorn.access) propagate to the root logger
+    # configured by setup_logging(), so access logs flow through the same
+    # configurable sinks (console / file / HTTP / Stackdriver). The
+    # /healthcheck noise is dropped by EndpointFilter attached above.
     uvicorn.run(
         "app.http_server.ingress:app",
         host="0.0.0.0",
         port=pydantic_settings.service_port,
         workers=pydantic_settings.workers,
         access_log=True,
-        log_config={
-            "version": 1,
-            "disable_existing_loggers": False,
-            "formatters": {
-                "access": {
-                    "()": "uvicorn.logging.AccessFormatter",
-                    "fmt": '%(asctime)s %(client_addr)s "%(request_line)s" %(status_code)s',
-                    "datefmt": "%d/%m/%Y %H:%M:%S",
-                },
-            },
-            "filters": {
-                "healthcheck": {
-                    "()": "app.http_server.ingress.EndpointFilter",
-                },
-            },
-            "handlers": {
-                "access": {
-                    "class": "logging.StreamHandler",
-                    "formatter": "access",
-                    "filters": ["healthcheck"],
-                    "stream": "ext://sys.stdout",
-                },
-            },
-            "loggers": {
-                "uvicorn.access": {
-                    "handlers": ["access"],
-                    "level": "INFO",
-                    "propagate": False,
-                },
-            },
-        },
+        log_config=None,
     )
 
 

--- a/app/http_server/ingress.py
+++ b/app/http_server/ingress.py
@@ -92,7 +92,7 @@ async def lifespan(app: FastAPI):
                         f"(celery={job_info['celery_status']}, action={job_info['action']})"
                     )
         except Exception as e:
-            logger.error(f"Startup orphaned job cleanup failed: {e}")
+            logger.exception(f"Startup orphaned job cleanup failed: {e}")
 
     # Startup: Model verification for all providers (non-blocking)
     async with AsyncSessionLocal() as db:
@@ -108,9 +108,9 @@ async def lifespan(app: FastAPI):
                     if verification.failed_count > 0:
                         logger.warning(f"Failed to verify {verification.failed_count} models for {provider.name}")
                 except Exception as e:
-                    logger.error(f"Error verifying models for provider {provider.name}: {e}")
+                    logger.exception(f"Error verifying models for provider {provider.name}: {e}")
         except Exception as e:
-            logger.error(f"Startup verification failed: {e}")
+            logger.exception(f"Startup verification failed: {e}")
 
     # Start periodic cleanup tasks
     cleanup_task = asyncio.create_task(periodic_cleanup())
@@ -271,7 +271,7 @@ async def periodic_orphan_monitor():
             except asyncio.CancelledError:
                 raise
             except Exception as e:
-                logger.error(f"Orphan monitor error: {e}")
+                logger.exception(f"Orphan monitor error: {e}")
 
             if shutdown_event.is_set():
                 break

--- a/app/seeds/base_seed.py
+++ b/app/seeds/base_seed.py
@@ -531,7 +531,7 @@ async def seed_global_document_templates(db: AsyncSession) -> int:
         logger.warning("document_templates.py not found - skipping")
         return 0
     except Exception as e:
-        logger.warning(f"Failed to seed global document templates: {e}")
+        logger.warning(f"Failed to seed global document templates: {e}", exc_info=True)
         return 0
 
 
@@ -631,7 +631,7 @@ async def run_seed(dev: bool = False, only: Optional[str] = None) -> dict:
             logger.info(f"Seed completed: {result}")
             return result
         except Exception as e:
-            logger.error(f"Seed failed: {e}")
+            logger.exception(f"Seed failed: {e}")
             raise
 
 

--- a/app/seeds/base_seed.py
+++ b/app/seeds/base_seed.py
@@ -44,8 +44,10 @@ from app.seeds.loader import (
     ServiceSeed,
 )
 
+from app.core.logging_config import setup_logging
+
+setup_logging(service="llm-gateway-seed")
 logger = logging.getLogger(__name__)
-logging.basicConfig(level=logging.INFO)
 
 
 async def get_or_create_provider(

--- a/app/seeds/loader.py
+++ b/app/seeds/loader.py
@@ -140,7 +140,7 @@ class SeedLoader:
                 loaded = self._load_prompts_from_manifest(prompt_subdir, manifest)
                 prompts.extend(loaded)
             except Exception as e:
-                logger.error(f"Failed to load prompts from {prompt_subdir}: {e}")
+                logger.exception(f"Failed to load prompts from {prompt_subdir}: {e}")
                 continue
 
         logger.info(f"Loaded {len(prompts)} prompts from {prompts_dir}")
@@ -173,7 +173,7 @@ class SeedLoader:
             try:
                 content = file_path.read_text(encoding="utf-8")
             except Exception as e:
-                logger.error(f"Failed to read {file_path}: {e}")
+                logger.exception(f"Failed to read {file_path}: {e}")
                 continue
 
             prompt_name = file_config.get("prompt_name", file_path.stem)
@@ -222,7 +222,7 @@ class SeedLoader:
                 if preset:
                     presets.append(preset)
             except Exception as e:
-                logger.error(f"Failed to load preset from {preset_subdir}: {e}")
+                logger.exception(f"Failed to load preset from {preset_subdir}: {e}")
                 continue
 
         logger.info(f"Loaded {len(presets)} presets from {presets_dir}")
@@ -286,7 +286,7 @@ class SeedLoader:
                 if provider:
                     providers.append(provider)
             except Exception as e:
-                logger.error(f"Failed to load provider from {provider_subdir}: {e}")
+                logger.exception(f"Failed to load provider from {provider_subdir}: {e}")
                 continue
 
         logger.info(f"Loaded {len(providers)} dev providers from {providers_dir}")
@@ -399,7 +399,7 @@ class SeedLoader:
                 if service:
                     services.append(service)
             except Exception as e:
-                logger.error(f"Failed to load service from {service_subdir}: {e}")
+                logger.exception(f"Failed to load service from {service_subdir}: {e}")
                 continue
 
         logger.info(f"Loaded {len(services)} dev services from {services_dir}")

--- a/app/services/document_service.py
+++ b/app/services/document_service.py
@@ -270,7 +270,7 @@ class DocumentService:
                     timeout=60  # 60 second timeout
                 )
             except subprocess.CalledProcessError as e:
-                logger.error(f"LibreOffice conversion failed: {e.stderr.decode()}")
+                logger.exception(f"LibreOffice conversion failed: {e.stderr.decode()}")
                 raise RuntimeError("PDF conversion failed")
             except FileNotFoundError:
                 raise RuntimeError("LibreOffice not installed. PDF export unavailable.")
@@ -312,7 +312,7 @@ class DocumentService:
             try:
                 tz = ZoneInfo(timezone)
             except (KeyError, ValueError):
-                logger.warning(f"Invalid timezone '{timezone}', falling back to UTC")
+                logger.warning(f"Invalid timezone '{timezone}', falling back to UTC", exc_info=True)
                 tz = ZoneInfo("UTC")
 
         now = datetime.now(tz) if tz else datetime.now()

--- a/app/services/document_template_service.py
+++ b/app/services/document_template_service.py
@@ -418,7 +418,7 @@ class DocumentTemplateService:
         try:
             from docx import Document
         except ImportError:
-            logger.warning("python-docx not installed, cannot extract placeholders")
+            logger.warning("python-docx not installed, cannot extract placeholders", exc_info=True)
             return []
 
         placeholders = set()
@@ -447,7 +447,7 @@ class DocumentTemplateService:
                         placeholders.update(re.findall(pattern, para.text))
 
         except Exception as e:
-            logger.warning(f"Error extracting placeholders from {file_path}: {e}")
+            logger.warning(f"Error extracting placeholders from {file_path}: {e}", exc_info=True)
 
         return sorted(list(placeholders))
 

--- a/app/services/export_service.py
+++ b/app/services/export_service.py
@@ -136,7 +136,7 @@ class ExportService:
                         await self._update_job_metadata(db, job, new_metadata, template_id=template_id)
                     logger.info(f"JIT extraction completed for job {job.id}, version={version_number}, extracted: {list(new_metadata.keys())}")
             except Exception as e:
-                logger.error(f"JIT extraction failed for job {job.id}: {e}")
+                logger.exception(f"JIT extraction failed for job {job.id}: {e}")
                 # Continue with export even if extraction fails
 
         # Get version-specific metadata for document generation
@@ -505,11 +505,11 @@ class ExportService:
             end_time = datetime.utcnow()
             duration_ms = int((end_time - start_time).total_seconds() * 1000)
 
-            logger.info(f"JIT extraction LLM response ({len(response)} chars): {response[:500]}...")
+            logger.info(f"JIT extraction LLM response ({len(response)} chars)")
 
             # Parse JSON response
             metadata = self._parse_json_response(response)
-            logger.info(f"JIT extraction parsed metadata: {metadata}")
+            logger.info(f"JIT extraction parsed metadata: {list(metadata.keys())}")
 
             # Filter to requested fields only
             if field_names:
@@ -527,10 +527,10 @@ class ExportService:
             return metadata
 
         except json.JSONDecodeError as e:
-            logger.error(f"Failed to parse extraction response as JSON: {e}")
+            logger.exception(f"Failed to parse extraction response as JSON: {e}")
             return {}
         except Exception as e:
-            logger.error(f"JIT extraction failed: {e}")
+            logger.exception(f"JIT extraction failed: {e}")
             return {}
 
     async def _update_job_metadata(
@@ -559,7 +559,7 @@ class ExportService:
         logger.info(f"Current metadata before merge: {list(current_metadata.keys())}")
         current_metadata.update(new_metadata)
         result["extracted_metadata"] = current_metadata
-        logger.info(f"Metadata after merge: {current_metadata}")
+        logger.info(f"Metadata after merge: {list(current_metadata.keys())}")
 
         # Track which template was used for extraction
         if template_id:

--- a/app/services/huggingface_service.py
+++ b/app/services/huggingface_service.py
@@ -52,7 +52,7 @@ class HuggingFaceService:
                 }
 
             except httpx.HTTPStatusError as e:
-                logger.error(f"HuggingFace API HTTP error for {repo_path}: {e}")
+                logger.exception(f"HuggingFace API HTTP error for {repo_path}: {e}")
                 return {
                     "found": False,
                     "repo_path": repo_path,
@@ -61,7 +61,7 @@ class HuggingFaceService:
                     "error": f"HTTP {e.response.status_code}: {e.response.reason_phrase}",
                 }
             except httpx.TimeoutException:
-                logger.error(f"HuggingFace API timeout for {repo_path}")
+                logger.exception(f"HuggingFace API timeout for {repo_path}")
                 return {
                     "found": False,
                     "repo_path": repo_path,
@@ -70,7 +70,7 @@ class HuggingFaceService:
                     "error": "Request timed out",
                 }
             except Exception as e:
-                logger.error(f"HuggingFace API error for {repo_path}: {e}")
+                logger.exception(f"HuggingFace API error for {repo_path}: {e}")
                 return {
                     "found": False,
                     "repo_path": repo_path,

--- a/app/services/job_service.py
+++ b/app/services/job_service.py
@@ -410,7 +410,7 @@ class JobService:
                 "message": "Job cancelled successfully",
             }
         except Exception as e:
-            logger.error(f"Failed to cancel job {job_id}: {e}")
+            logger.exception(f"Failed to cancel job {job_id}: {e}")
             return {
                 "job_id": job_id,
                 "status": "failed",
@@ -523,7 +523,7 @@ class JobService:
                         f"(db_status={job.status}, celery_status={celery_status})"
                     )
             except Exception as e:
-                logger.warning(f"Error checking Celery status for job {job.id}: {e}")
+                logger.warning(f"Error checking Celery status for job {job.id}: {e}", exc_info=True)
                 # If we can't check Celery, treat old jobs as potentially orphaned
                 cutoff = datetime.utcnow() - timedelta(minutes=DEFAULT_STALE_TIMEOUT_MINUTES)
                 if job.started_at and job.started_at < cutoff:

--- a/app/services/metadata_extraction_service.py
+++ b/app/services/metadata_extraction_service.py
@@ -158,10 +158,10 @@ class MetadataExtractionService:
             return metadata
 
         except json.JSONDecodeError as e:
-            logger.error(f"Failed to parse extraction response as JSON: {e}")
+            logger.exception(f"Failed to parse extraction response as JSON: {e}")
             return {"_extraction_error": f"JSON parse error: {str(e)}"}
         except Exception as e:
-            logger.error(f"Metadata extraction failed: {e}")
+            logger.exception(f"Metadata extraction failed: {e}")
             return {"_extraction_error": str(e)}
 
     async def extract_with_prompt(

--- a/app/services/model_service.py
+++ b/app/services/model_service.py
@@ -329,7 +329,7 @@ class ModelService:
         try:
             api_key = self.encryption_service.decrypt(provider.api_key_encrypted)
         except Exception as e:
-            logger.error(f"Failed to decrypt API key for provider {provider_id}: {e}")
+            logger.exception(f"Failed to decrypt API key for provider {provider_id}: {e}")
             raise HTTPException(
                 status_code=500,
                 detail="Failed to decrypt provider credentials"
@@ -360,7 +360,7 @@ class ModelService:
                 timeout
             )
         except Exception as e:
-            logger.error(f"Failed to fetch models from provider API: {e}")
+            logger.exception(f"Failed to fetch models from provider API: {e}")
             raise HTTPException(
                 status_code=503,
                 detail=f"Provider API unreachable: {str(e)}"
@@ -607,7 +607,7 @@ class ModelService:
         try:
             api_key = self.encryption_service.decrypt(provider.api_key_encrypted)
         except Exception as e:
-            logger.error(f"Failed to decrypt API key: {e}")
+            logger.exception(f"Failed to decrypt API key: {e}")
             return {
                 "available": False,
                 "error": "Failed to decrypt provider credentials",
@@ -861,7 +861,7 @@ class ModelService:
                 "details": {}
             }
         except Exception as e:
-            logger.error(f"Custom model verification error: {e}")
+            logger.exception(f"Custom model verification error: {e}")
             return {
                 "available": False,
                 "error": f"Verification failed: {str(e)}",
@@ -891,7 +891,7 @@ class ModelService:
         try:
             api_key = self.encryption_service.decrypt(provider.api_key_encrypted)
         except Exception as e:
-            logger.error(f"Failed to decrypt API key: {e}")
+            logger.exception(f"Failed to decrypt API key: {e}")
             raise HTTPException(
                 status_code=500,
                 detail="Failed to decrypt provider credentials"
@@ -1191,7 +1191,7 @@ class ModelService:
                 logger.warning(f"Failed to preload tokenizer for {model.model_identifier}: {result.message}")
         except Exception as e:
             # Non-blocking: log warning but don't fail the operation
-            logger.warning(f"Tokenizer preload failed for {model.model_identifier}: {e}")
+            logger.warning(f"Tokenizer preload failed for {model.model_identifier}: {e}", exc_info=True)
 
     async def get_model_limits(
         self,

--- a/app/services/tokenizer_manager.py
+++ b/app/services/tokenizer_manager.py
@@ -204,7 +204,7 @@ class TokenizerManager:
             logger.debug(f"Loaded tiktoken encoding: {encoding_name}")
             return wrapper
         except Exception as e:
-            logger.error(f"Failed to load tiktoken encoding {encoding_name}: {e}")
+            logger.exception(f"Failed to load tiktoken encoding {encoding_name}: {e}")
             raise
 
     def _load_from_local(self, tokenizer_id: str) -> Optional[HuggingFaceWrapper]:
@@ -223,7 +223,7 @@ class TokenizerManager:
             logger.debug(f"Loaded tokenizer from local storage: {tokenizer_id}")
             return wrapper
         except Exception as e:
-            logger.error(f"Failed to load tokenizer from local: {tokenizer_id}: {e}")
+            logger.exception(f"Failed to load tokenizer from local: {tokenizer_id}: {e}")
             return None
 
     def _download_and_save(self, tokenizer_id: str) -> HuggingFaceWrapper:
@@ -244,7 +244,7 @@ class TokenizerManager:
             self._memory_cache[tokenizer_id] = wrapper
             return wrapper
         except Exception as e:
-            logger.error(f"Failed to download tokenizer {tokenizer_id}: {e}")
+            logger.exception(f"Failed to download tokenizer {tokenizer_id}: {e}")
             raise
 
     def _resolve_tokenizer_config(self, model) -> Dict[str, Any]:
@@ -324,9 +324,9 @@ class TokenizerManager:
         try:
             return self._download_and_save(repo)
         except Exception as e:
-            logger.error(f"Failed to load HuggingFace tokenizer {repo}: {e}")
+            logger.exception(f"Failed to load HuggingFace tokenizer {repo}: {e}")
             # Fallback to tiktoken
-            logger.warning(f"Falling back to tiktoken for model {model.model_identifier}")
+            logger.warning(f"Falling back to tiktoken for model {model.model_identifier}", exc_info=True)
             return self._load_tiktoken("cl100k_base")
 
     def count_tokens(self, model, text: str) -> int:
@@ -395,7 +395,7 @@ class TokenizerManager:
                     message="Tokenizer already cached locally",
                 )
             except Exception as e:
-                logger.warning(f"Cached tokenizer corrupted, re-downloading: {e}")
+                logger.warning(f"Cached tokenizer corrupted, re-downloading: {e}", exc_info=True)
 
         # Download and save
         try:
@@ -409,7 +409,7 @@ class TokenizerManager:
                 message="Tokenizer downloaded and persisted",
             )
         except Exception as e:
-            logger.error(f"Failed to preload tokenizer for {model_identifier}: {e}")
+            logger.exception(f"Failed to preload tokenizer for {model_identifier}: {e}")
             return PreloadResult(
                 success=False,
                 model_identifier=model_identifier,

--- a/docs/LOGGING_GUIDE.md
+++ b/docs/LOGGING_GUIDE.md
@@ -1,0 +1,197 @@
+# Logging Guide
+
+LLM Gateway uses a single, configurable logging setup driven by environment
+variables. It can write human readable text to stdout (the default) or
+structured JSON, and ship logs to one or more destinations at the same time:
+console, a rotating file, an HTTP collector, or Google Cloud Logging
+(Stackdriver).
+
+Logging is configured once at process startup (API server, Celery workers and
+seed scripts) by `app/core/logging_config.py`. You do not call it yourself.
+
+## Quick Start
+
+The defaults work out of the box (text logs on stdout at `INFO`). To customize,
+set variables in your `.env`:
+
+```bash
+# .env
+LOG_LEVEL=INFO        # DEBUG / INFO / WARNING / ERROR
+LOG_FORMAT=text       # text (default) or json
+```
+
+Set `LOG_FORMAT=json` as soon as you collect logs with an aggregator (Loki, ELK,
+Cloud Logging) that scrapes container stdout. JSON keeps the fields structured.
+
+## Configuration Modes
+
+There are two ways to configure logging, in order of precedence:
+
+1. **`LOGGING_CONFIG_FILE`** points to a JSON file passed verbatim to Python's
+   [`logging.config.dictConfig`](https://docs.python.org/3/library/logging.config.html#logging-config-dictschema).
+   This gives full control over formatters, handlers and loggers. When set, all
+   the `LOG_*` variables below are ignored. This is the equivalent of the LinTO
+   Studio API `WINSTON_CONFIG_PATH`.
+
+2. **Environment variables** (the common case), documented below.
+
+## Environment Variables
+
+### General
+
+| Variable             | Description                                              | Default        |
+|----------------------|----------------------------------------------------------|----------------|
+| `LOG_LEVEL`          | Root level: `DEBUG` / `INFO` / `WARNING` / `ERROR`       | `INFO`         |
+| `LOG_FORMAT`         | `text` or `json`                                         | `text`         |
+| `LOG_NAME`           | Service label added to JSON / Stackdriver entries        | `llm-gateway`  |
+| `DEBUG`              | When `true`, forces `LOG_LEVEL` to `DEBUG`               | `false`        |
+| `LOGGING_CONFIG_FILE`| Path to a `dictConfig` JSON file (full override)         | (unset)        |
+
+Each sink below is **disabled until its trigger variable is set**. The console
+sink (stdout) is always on. Every sink has an optional dedicated level that
+falls back to `LOG_LEVEL` when left empty, so you can, for example, keep `INFO`
+on the console while only shipping `ERROR` over HTTP.
+
+### Rotating File
+
+Trigger: `LOG_FILE`.
+
+| Variable                | Description                          | Default        |
+|-------------------------|--------------------------------------|----------------|
+| `LOG_FILE`              | Path to the log file (enables sink)  | (unset)        |
+| `LOG_FILE_LEVEL`        | Level for this sink                  | `LOG_LEVEL`    |
+| `LOG_FILE_MAX_BYTES`    | Rotate after this size               | `10485760` (10 MiB) |
+| `LOG_FILE_BACKUP_COUNT` | Number of rotated files to keep      | `5`            |
+
+### HTTP POST
+
+Trigger: `LOG_HTTP_URL`. Each record is shipped as a JSON document via HTTP POST
+to a centralized collector (Logstash HTTP input, Loki, Datadog, a custom
+endpoint, etc.). The POST runs on a background queue, so it never blocks the
+request or worker thread, and network errors are swallowed so logging cannot
+crash the app. Records are always sent as JSON regardless of `LOG_FORMAT`.
+
+| Variable           | Description                                          | Default     |
+|--------------------|------------------------------------------------------|-------------|
+| `LOG_HTTP_URL`     | Collector URL (enables sink)                         | (unset)     |
+| `LOG_HTTP_METHOD`  | HTTP method                                          | `POST`      |
+| `LOG_HTTP_HEADERS` | Extra headers as a JSON object (e.g. auth token)     | `{}`        |
+| `LOG_HTTP_LEVEL`   | Level for this sink                                  | `LOG_LEVEL` |
+| `LOG_HTTP_TIMEOUT` | Per-request timeout in seconds                       | `5.0`       |
+
+### Google Cloud Logging (Stackdriver)
+
+Trigger: `LOG_STACKDRIVER_ENABLED`. Requires the optional `google-cloud-logging`
+package (commented in `requirements.txt`; uncomment to install). If the package
+is missing, the sink is skipped with a warning rather than failing startup.
+
+| Variable                    | Description                                  | Default     |
+|-----------------------------|----------------------------------------------|-------------|
+| `LOG_STACKDRIVER_ENABLED`   | Enable the sink                              | `false`     |
+| `LOG_STACKDRIVER_PROJECT`   | GCP project id (auto-detected when empty)    | (auto)      |
+| `LOG_STACKDRIVER_LEVEL`     | Level for this sink                          | `LOG_LEVEL` |
+
+Authentication uses standard Google credentials
+([Application Default Credentials](https://cloud.google.com/docs/authentication/application-default-credentials)):
+a `GOOGLE_APPLICATION_CREDENTIALS` service account file, or the workload identity
+of the GKE pod / GCE instance.
+
+## JSON Output
+
+With `LOG_FORMAT=json`, each line is a JSON object with ISO-8601 timestamps:
+
+```json
+{"timestamp": "2026-06-16T20:02:43.123+02:00", "level": "INFO", "logger": "http_server", "service": "llm-gateway-api", "message": "Starting FastAPI application...", "job_id": "abc"}
+```
+
+| Field       | Source                                                        |
+|-------------|---------------------------------------------------------------|
+| `timestamp` | record time, ISO-8601 with milliseconds (renamed from `asctime`) |
+| `level`     | log level (renamed from `levelname`)                          |
+| `logger`    | logger name (renamed from `name`)                             |
+| `service`   | value of `LOG_NAME`, or the per-process label (see below)     |
+| `message`   | the log message                                               |
+| *extras*    | any keyword passed via `logger.info(msg, extra={...})`        |
+
+The `service` field is set per process so you can tell them apart:
+`llm-gateway-api` (HTTP server), `llm-gateway-worker` (Celery), `llm-gateway-seed`
+(seed scripts).
+
+## Examples
+
+### Ship JSON to an HTTP collector with an auth token
+
+```bash
+# .env
+LOG_FORMAT=json
+LOG_HTTP_URL=https://logs.example.com/ingest
+LOG_HTTP_HEADERS={"Authorization": "Bearer my-token"}
+LOG_HTTP_LEVEL=INFO
+```
+
+### Console at INFO, errors also to a rotating file
+
+```bash
+LOG_LEVEL=INFO
+LOG_FILE=/var/log/llm-gateway/app.log
+LOG_FILE_LEVEL=ERROR
+```
+
+### Google Cloud Logging on GKE
+
+```bash
+# requirements.txt: uncomment google-cloud-logging, then rebuild the image
+LOG_STACKDRIVER_ENABLED=true
+LOG_STACKDRIVER_PROJECT=my-gcp-project
+```
+
+### Full control via a dictConfig file
+
+```bash
+LOGGING_CONFIG_FILE=/app/config/logging.json
+```
+
+```json
+{
+  "version": 1,
+  "disable_existing_loggers": false,
+  "formatters": {
+    "json": {
+      "()": "pythonjsonlogger.json.JsonFormatter",
+      "format": "%(asctime)s %(levelname)s %(name)s %(message)s"
+    }
+  },
+  "handlers": {
+    "console": { "class": "logging.StreamHandler", "formatter": "json" }
+  },
+  "root": { "handlers": ["console"], "level": "INFO" }
+}
+```
+
+The custom HTTP handler is importable for use in a dictConfig file as
+`app.core.logging_config.HTTPJSONHandler` (params: `url`, `method`, `headers`,
+`timeout`).
+
+## Notes
+
+- **Uvicorn access logs** flow through the same sinks (uvicorn is started with
+  `log_config=None` so its loggers propagate to the root logger). `GET /healthcheck`
+  requests are filtered out to keep the output clean.
+- **Celery workers** are configured via the `setup_logging` and
+  `worker_process_init` signals, so the configured sinks apply to task logs in
+  every forked worker process.
+- **Hot-reload**: the gateway backend runs in Docker, where Python hot-reload may
+  not pick up changes reliably. After changing logging env vars, restart the
+  `llm-gateway` and `celery-worker` containers.
+
+## Using a Logger in Code
+
+Nothing special is required. Get a module logger and use it; it inherits the
+configured sinks, level and format:
+
+```python
+import logging
+
+logger = logging.getLogger(__name__)
+logger.info("processing job", extra={"job_id": job_id})  # extras become JSON fields
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -25,6 +25,12 @@ alembic>=1.13.0
 pydantic>=2.0.0
 pydantic-settings>=2.0.0
 
+# Logging (structured JSON output for centralized log shipping)
+python-json-logger>=2.0.0
+# Optional: enable the Stackdriver / Google Cloud Logging sink
+# (LOG_STACKDRIVER_ENABLED=true). Uncomment to install.
+# google-cloud-logging>=3.0.0
+
 # Security and Encryption
 cryptography>=41.0.0
 psycopg2-binary>=2.9.0

--- a/tests/test_logging_config.py
+++ b/tests/test_logging_config.py
@@ -1,0 +1,256 @@
+"""Configurable logging - unit tests.
+
+Covers the env-driven sink selection (console / rotating file / HTTP POST),
+text-vs-JSON formatting, level resolution, the dictConfig file override, and the
+HTTPJSONHandler shipping behaviour. Each test snapshots and restores the root
+logger so it does not leak handlers into the rest of the suite.
+"""
+import json
+import logging
+import logging.handlers
+from unittest.mock import patch, MagicMock
+
+import pytest
+
+from app.core.config import settings
+import app.core.logging_config as lc
+from app.core.logging_config import (
+    setup_logging,
+    HTTPJSONHandler,
+    ServiceFilter,
+    _name_to_level,
+    _parse_headers,
+)
+
+
+LOG_ATTRS = (
+    "logging_config_file", "log_level", "log_format", "log_name",
+    "log_file", "log_file_level", "log_file_max_bytes", "log_file_backup_count",
+    "log_http_url", "log_http_method", "log_http_headers", "log_http_level",
+    "log_http_timeout", "log_stackdriver_enabled", "log_stackdriver_project",
+    "log_stackdriver_level", "debug",
+)
+
+
+@pytest.fixture
+def clean_logging():
+    """Restore root logger + module state and reset logging defaults around each test."""
+    root = logging.getLogger()
+    saved_handlers = list(root.handlers)
+    saved_level = root.level
+    saved_settings = {a: getattr(settings, a) for a in LOG_ATTRS}
+    saved_listener = lc._listener
+    saved_configured = lc._configured
+
+    # Known baseline for the test body.
+    settings.logging_config_file = ""
+    settings.log_level = "INFO"
+    settings.log_format = "text"
+    settings.log_name = "llm-gateway-test"
+    settings.log_file = ""
+    settings.log_file_level = ""
+    settings.log_http_url = ""
+    settings.log_http_level = ""
+    settings.log_http_method = "POST"
+    settings.log_http_headers = ""
+    settings.log_http_timeout = 5.0
+    settings.log_stackdriver_enabled = False
+    settings.debug = False
+    lc._listener = None
+
+    yield
+
+    lc._safe_stop_listener()
+    lc._listener = saved_listener
+    lc._configured = saved_configured
+    for a, v in saved_settings.items():
+        setattr(settings, a, v)
+    for h in list(root.handlers):
+        root.removeHandler(h)
+    for h in saved_handlers:
+        root.addHandler(h)
+    root.setLevel(saved_level)
+
+
+def _capture_console(buf):
+    """Point the console StreamHandler at an in-memory buffer."""
+    for h in logging.getLogger().handlers:
+        if isinstance(h, logging.StreamHandler) and not isinstance(h, logging.handlers.QueueHandler):
+            h.stream = buf
+
+
+# --------------------------------------------------------------------------- #
+# Formatting
+# --------------------------------------------------------------------------- #
+
+def test_text_format_is_default(clean_logging):
+    setup_logging(force=True)
+    root = logging.getLogger()
+    handlers = [type(h).__name__ for h in root.handlers]
+    assert handlers == ["StreamHandler"]
+    assert isinstance(root.handlers[0].formatter, logging.Formatter)
+
+
+def test_json_format_emits_structured_record(clean_logging):
+    import io
+    settings.log_format = "json"
+    setup_logging(service="svc-x", force=True)
+    buf = io.StringIO()
+    _capture_console(buf)
+
+    logging.getLogger("demo").info("hello", extra={"job_id": "abc"})
+
+    record = json.loads(buf.getvalue().strip())
+    assert record["level"] == "INFO"
+    assert record["logger"] == "demo"
+    assert record["service"] == "svc-x"
+    assert record["message"] == "hello"
+    assert record["job_id"] == "abc"        # extra fields are preserved
+    # asctime renamed to timestamp, ISO-8601 with millisecond precision
+    assert "timestamp" in record
+    from datetime import datetime
+    parsed_ts = datetime.fromisoformat(record["timestamp"])
+    assert parsed_ts.tzinfo is not None     # carries a timezone offset
+    assert "." in record["timestamp"]       # sub-second precision present
+
+
+# --------------------------------------------------------------------------- #
+# Level resolution
+# --------------------------------------------------------------------------- #
+
+def test_log_level_applied(clean_logging):
+    settings.log_level = "WARNING"
+    setup_logging(force=True)
+    assert logging.getLogger().level == logging.WARNING
+
+
+def test_debug_flag_forces_debug(clean_logging):
+    settings.log_level = "WARNING"
+    settings.debug = True
+    setup_logging(force=True)
+    assert logging.getLogger().level == logging.DEBUG
+
+
+@pytest.mark.parametrize("value,expected", [
+    ("DEBUG", logging.DEBUG),
+    ("warning", logging.WARNING),
+    ("", logging.INFO),       # empty -> default
+    ("NOPE", logging.INFO),   # invalid -> default
+])
+def test_name_to_level(value, expected):
+    assert _name_to_level(value, logging.INFO) == expected
+
+
+# --------------------------------------------------------------------------- #
+# Sinks
+# --------------------------------------------------------------------------- #
+
+def test_file_sink_enabled(clean_logging, tmp_path):
+    settings.log_file = str(tmp_path / "app.log")
+    setup_logging(force=True)
+    file_handlers = [
+        h for h in logging.getLogger().handlers
+        if isinstance(h, logging.handlers.RotatingFileHandler)
+    ]
+    assert len(file_handlers) == 1
+    assert file_handlers[0].maxBytes == settings.log_file_max_bytes
+
+
+def test_http_sink_uses_background_listener(clean_logging):
+    settings.log_http_url = "http://collector.local/ingest"
+    settings.log_http_level = "ERROR"
+    setup_logging(force=True)
+
+    root = logging.getLogger()
+    queue_handlers = [h for h in root.handlers if isinstance(h, logging.handlers.QueueHandler)]
+    assert len(queue_handlers) == 1
+    assert lc._listener is not None
+    assert lc._listener._thread.is_alive()
+
+    shipped = lc._listener.handlers[0]
+    assert isinstance(shipped, HTTPJSONHandler)
+    assert shipped.level == logging.ERROR     # per-sink level honoured
+    assert shipped.url == "http://collector.local/ingest"
+
+
+def test_no_sink_without_trigger(clean_logging):
+    setup_logging(force=True)
+    root = logging.getLogger()
+    assert not any(isinstance(h, logging.handlers.QueueHandler) for h in root.handlers)
+    assert not any(isinstance(h, logging.handlers.RotatingFileHandler) for h in root.handlers)
+
+
+# --------------------------------------------------------------------------- #
+# dictConfig override
+# --------------------------------------------------------------------------- #
+
+def test_config_file_override_takes_precedence(clean_logging, tmp_path):
+    override = {
+        "version": 1,
+        "disable_existing_loggers": False,
+        "handlers": {"c": {"class": "logging.StreamHandler"}},
+        "root": {"handlers": ["c"], "level": "WARNING"},
+    }
+    cfg_path = tmp_path / "logging.json"
+    cfg_path.write_text(json.dumps(override))
+
+    settings.logging_config_file = str(cfg_path)
+    settings.log_http_url = "http://should-be-ignored.local"
+    setup_logging(force=True)
+
+    # The env-driven HTTP sink must be ignored when a dictConfig file is given.
+    assert logging.getLogger().level == logging.WARNING
+    assert not any(
+        isinstance(h, logging.handlers.QueueHandler)
+        for h in logging.getLogger().handlers
+    )
+
+
+# --------------------------------------------------------------------------- #
+# HTTPJSONHandler / helpers
+# --------------------------------------------------------------------------- #
+
+def test_http_handler_posts_json_with_headers():
+    handler = HTTPJSONHandler(
+        "http://collector.local/ingest",
+        headers={"Authorization": "Bearer t"},
+    )
+    handler.setFormatter(logging.Formatter("%(message)s"))
+    record = logging.LogRecord("n", logging.INFO, __file__, 1, "payload", None, None)
+
+    with patch("urllib.request.urlopen") as urlopen:
+        urlopen.return_value.__enter__.return_value = MagicMock()
+        handler.emit(record)
+
+    request = urlopen.call_args[0][0]
+    assert request.full_url == "http://collector.local/ingest"
+    assert request.method == "POST"
+    assert request.data == b"payload"
+    assert request.headers["Content-type"] == "application/json"
+    assert request.headers["Authorization"] == "Bearer t"
+
+
+def test_http_handler_swallows_network_errors():
+    handler = HTTPJSONHandler("http://collector.local/ingest")
+    handler.setFormatter(logging.Formatter("%(message)s"))
+    record = logging.LogRecord("n", logging.INFO, __file__, 1, "x", None, None)
+    with patch("urllib.request.urlopen", side_effect=OSError("boom")), \
+         patch.object(handler, "handleError") as handle_error:
+        handler.emit(record)        # must not raise
+        handle_error.assert_called_once()
+
+
+def test_service_filter_injects_attribute():
+    record = logging.LogRecord("n", logging.INFO, __file__, 1, "x", None, None)
+    assert ServiceFilter("my-svc").filter(record) is True
+    assert record.service == "my-svc"
+
+
+@pytest.mark.parametrize("raw,expected", [
+    ("", {}),
+    ('{"A": "B"}', {"A": "B"}),
+    ("not-json", {}),
+    ('["list", "not", "object"]', {}),
+])
+def test_parse_headers(raw, expected):
+    assert _parse_headers(raw) == expected


### PR DESCRIPTION
## Why

Logging was 5 scattered `basicConfig()` calls, plain text on stdout only, with a single `DEBUG` toggle. No way to ship logs to a centralized system. This makes logging configurable like the LinTO Studio API (Winston): selectable sinks, text or JSON, per-sink levels.

## Commit 1 — feature: configurable logging

- Central `app/core/logging_config.py` (`setup_logging`), called once per process (API, Celery, seeds), replacing the scattered `basicConfig` calls.
- Driven by env vars (`LOG_LEVEL`, `LOG_FORMAT` text|json, `LOG_NAME`, per-sink levels) or a full `dictConfig` JSON file via `LOGGING_CONFIG_FILE` (Winston `WINSTON_CONFIG_PATH` equivalent).
- Sinks: console, rotating file, non-blocking HTTP POST (background queue), Google Cloud Logging / Stackdriver (optional dep).
- JSON logs: ISO-8601 timestamps with millisecond precision, `service` label per process, `extra={...}` fields preserved.
- uvicorn access logs flow through the same sinks (`log_config=None`), `/healthcheck` still filtered.
- Adds `python-json-logger`, `docs/LOGGING_GUIDE.md`, and `tests/test_logging_config.py` (19 tests).

## Commit 2 — fix: exception & content logging quality

- Tracebacks: 71 `except` handlers logged only the exception string. Converted `logger.error` -> `logger.exception` and added `exc_info=True` to `warning`/`critical` inside `except` blocks. `logger.exception` count 1 -> 83, `exc_info=True` 0 -> 16.
- Privacy: stopped dumping LLM responses, extracted document content and prompt bodies in logs (kept lengths, field names and ids). Notably the JIT-extraction INFO log no longer logs document content.

## Verification

- AST check: every `logger.exception` / `exc_info=True` sits inside an active `except` (no "NoneType: None").
- Only logging lines changed in the reviewed files — no control-flow/behavior changes.
- `py_compile` OK on all changed files; 775 tests collect with no import errors; 186 passed / 0 failed on the subset touching the changed modules.

## Notes

- `google-cloud-logging` is left commented in `requirements.txt` (optional, lazy-imported); uncomment to enable the Stackdriver sink.
- Default behavior is unchanged: text logs on stdout. Set `LOG_FORMAT=json` for aggregators.