### PR TITLE
feat: multi org/user scoping for services & templates + service↔template links

### DIFF
--- a/app/api/v1/services.py
+++ b/app/api/v1/services.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python3
 import logging
 import uuid as uuid_module
-from typing import Any, Dict, Optional
+from typing import Any, Dict, List, Optional
 from uuid import UUID
 from fastapi import APIRouter, Depends, HTTPException, Query, status, UploadFile, File, Form
 from sqlalchemy.ext.asyncio import AsyncSession
@@ -16,6 +16,7 @@ from app.schemas.service import (
     ServiceCreate,
     ServiceUpdate,
     ServiceResponse,
+    ServiceTemplatesUpdate,
     ServiceFlavorCreate,
     ServiceFlavorUpdate,
     ServiceFlavorResponse,
@@ -29,6 +30,7 @@ from app.schemas.service import (
     ValidateFailoverRequest,
     ValidateFailoverResponse,
 )
+from app.schemas.template import TemplateResponse
 from app.schemas.common import ErrorResponse, PaginatedResponse
 
 logger = logging.getLogger(__name__)
@@ -211,7 +213,8 @@ async def create_service(
 async def list_services(
     service_type: Optional[str] = Query(None, description="Filter by service type"),
     is_active: Optional[bool] = Query(None, description="Filter by active status"),
-    organization_id: Optional[str] = Query(None, description="Visibility filter - returns global services + org-specific services"),
+    organization_id: Optional[str] = Query(None, description="Visibility filter - returns global services + services allowing this org"),
+    user_id: Optional[str] = Query(None, description="Visibility filter - also returns services allowing this user"),
     page: int = Query(1, ge=1, description="Page number"),
     page_size: int = Query(50, ge=1, le=100, description="Items per page"),
     db: AsyncSession = Depends(get_db)
@@ -221,7 +224,8 @@ async def list_services(
 
     - **service_type**: Filter by service type
     - **is_active**: Filter by active status
-    - **organization_id**: Visibility filter - returns global services (no org) plus services matching this org ID
+    - **organization_id**: Visibility filter - returns global services (no scope) plus services whose allowed orgs include this ID
+    - **user_id**: Visibility filter - also returns services whose allowed users include this ID
     - **page**: Page number (default: 1)
     - **page_size**: Items per page (default: 50, max: 100)
     """
@@ -232,6 +236,7 @@ async def list_services(
             service_type=service_type,
             is_active=is_active,
             organization_id=organization_id,
+            user_id=user_id,
             skip=skip,
             limit=page_size
         )
@@ -335,6 +340,71 @@ async def delete_service(
             status_code=status.HTTP_400_BAD_REQUEST,
             detail=f"Failed to delete service: {str(e)}"
         )
+
+
+# =============================================================================
+# Service <-> Document Template links
+# =============================================================================
+
+@router.get(
+    "/services/{service_id}/templates",
+    response_model=List[TemplateResponse],
+    responses={404: {"model": ErrorResponse}},
+)
+async def list_service_templates(
+    service_id: UUID,
+    organization_id: Optional[str] = Query(None, description="Visibility filter by organization"),
+    user_id: Optional[str] = Query(None, description="Visibility filter by user"),
+    db: AsyncSession = Depends(get_db),
+) -> List[TemplateResponse]:
+    """
+    List the document templates available for a service.
+
+    - If the service has explicitly linked templates, returns those (filtered by
+      the caller's org/user visibility when provided).
+    - If it has none, falls back to the global default template.
+    """
+    try:
+        return await service_service.get_service_templates(
+            db, service_id, organization_id=organization_id, user_id=user_id
+        )
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error listing service templates: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_500_INTERNAL_SERVER_ERROR,
+            detail=f"Failed to list service templates: {str(e)}"
+        )
+
+
+@router.put(
+    "/services/{service_id}/templates",
+    response_model=ServiceResponse,
+    responses={404: {"model": ErrorResponse}},
+)
+async def set_service_templates(
+    service_id: UUID,
+    request: ServiceTemplatesUpdate,
+    db: AsyncSession = Depends(get_db),
+) -> ServiceResponse:
+    """
+    Replace the set of document templates available for a service.
+
+    - **template_ids**: full list of template IDs to link (empty clears all links,
+      which makes the service fall back to the global default template).
+    """
+    try:
+        return await service_service.set_service_templates(db, service_id, request.template_ids)
+    except HTTPException:
+        raise
+    except Exception as e:
+        logger.error(f"Error setting service templates: {e}")
+        raise HTTPException(
+            status_code=status.HTTP_400_BAD_REQUEST,
+            detail=f"Failed to set service templates: {str(e)}"
+        )
+
 
 # Flavor CRUD endpoints
 

--- a/app/api/v1/templates.py
+++ b/app/api/v1/templates.py
@@ -36,9 +36,12 @@ async def upload_template(
     name_en: Optional[str] = Form(None, max_length=255, description="English name"),
     description_fr: Optional[str] = Form(None, description="French description"),
     description_en: Optional[str] = Form(None, description="English description"),
-    # Using str instead of UUID for flexibility with external systems (MongoDB ObjectIds, etc.)
-    organization_id: Optional[str] = Form(None, max_length=100, description="Organization scope (null for system)"),
-    user_id: Optional[str] = Form(None, max_length=100, description="User scope (null for org/system)"),
+    # Multi-scope access lists (repeat the field to add several IDs). Both empty => system.
+    allowed_organization_ids: List[str] = Form(default=[], description="Organizations allowed to see the template"),
+    allowed_user_ids: List[str] = Form(default=[], description="Users allowed to see the template"),
+    # Deprecated single-scope aliases (folded into the lists). Free-form string IDs.
+    organization_id: Optional[str] = Form(None, max_length=100, description="Deprecated: single organization scope"),
+    user_id: Optional[str] = Form(None, max_length=100, description="Deprecated: single user scope"),
     is_default: bool = Form(False, description="Set as default for scope"),
     db: AsyncSession = Depends(get_db),
 ) -> TemplateResponse:
@@ -48,10 +51,10 @@ async def upload_template(
     The template file must be a valid DOCX document. Placeholders in the format
     {{placeholder_name}} will be automatically extracted.
 
-    Scope hierarchy:
-    - System templates: organization_id=null, user_id=null (visible to all)
-    - Organization templates: organization_id=X, user_id=null (visible to org X)
-    - User templates: organization_id=X, user_id=Y (visible only to user Y)
+    Scope (multi):
+    - System templates: both lists empty (visible to all)
+    - Organization templates: orgs listed in allowed_organization_ids
+    - User templates: users listed in allowed_user_ids
 
     Maximum file size: 10 MB.
     """
@@ -63,6 +66,8 @@ async def upload_template(
             name_en=name_en,
             description_fr=description_fr,
             description_en=description_en,
+            allowed_organization_ids=allowed_organization_ids,
+            allowed_user_ids=allowed_user_ids,
             organization_id=organization_id,
             user_id=user_id,
             is_default=is_default,
@@ -147,15 +152,27 @@ async def update_template(
     name_en: Optional[str] = Form(None, max_length=255, description="English name"),
     description_fr: Optional[str] = Form(None, description="French description"),
     description_en: Optional[str] = Form(None, description="English description"),
+    # Scope edit: pass either list to replace the template's audience.
+    allowed_organization_ids: Optional[List[str]] = Form(None, description="Replace organizations allowed to see the template"),
+    allowed_user_ids: Optional[List[str]] = Form(None, description="Replace users allowed to see the template"),
+    # When true, the access lists are replaced even if empty (clears scope to
+    # system). Needed because multipart cannot send an explicit empty list.
+    replace_scope: bool = Form(False, description="Replace scope with the given lists, even when empty"),
     is_default: Optional[bool] = Form(None, description="Set as default"),
     db: AsyncSession = Depends(get_db),
 ) -> TemplateResponse:
     """
-    Update template metadata and/or file.
+    Update template metadata, scope and/or file.
 
     All fields are optional - only provided fields will be updated.
     If a new file is provided, placeholders will be re-extracted.
+    Passing allowed_organization_ids / allowed_user_ids (or replace_scope=true)
+    replaces the template scope.
     """
+    if replace_scope:
+        # Coerce missing lists to empty so an empty audience (system) can be set.
+        allowed_organization_ids = allowed_organization_ids or []
+        allowed_user_ids = allowed_user_ids or []
     try:
         template = await document_template_service.update_template(
             db=db,
@@ -165,6 +182,8 @@ async def update_template(
             name_en=name_en,
             description_fr=description_fr,
             description_en=description_en,
+            allowed_organization_ids=allowed_organization_ids,
+            allowed_user_ids=allowed_user_ids,
             is_default=is_default,
         )
         if not template:

--- a/app/http_server/ingress.py
+++ b/app/http_server/ingress.py
@@ -138,7 +138,7 @@ async def lifespan(app: FastAPI):
 app = FastAPI(
     title=pydantic_settings.app_name,
     description=pydantic_settings.app_description,
-    version="1.0.0",
+    version="1.1.0",
     docs_url=pydantic_settings.docs_url,
     redoc_url="/redoc",
     lifespan=lifespan,

--- a/app/migrations/versions/008_multi_scope_and_service_templates.py
+++ b/app/migrations/versions/008_multi_scope_and_service_templates.py
@@ -1,0 +1,131 @@
+"""multi_scope_and_service_templates - multi org/user scoping + service<->template links
+
+Revision ID: 008
+Revises: 007
+Create Date: 2026-06-19 00:00:00.000000
+
+Adds list-based scoping (allowed_organization_ids / allowed_user_ids) to both
+`services` and `document_templates`, so a resource can be granted to several
+organizations and/or several users instead of a single one. The legacy scalar
+columns (services.organization_id, document_templates.organization_id/user_id)
+are kept and back-compat-derived so existing clients (LinTO Studio) keep working.
+
+Also adds the `service_document_templates` junction table letting admins choose
+which document templates are available for which service (empty set => the
+service falls back to the global default template).
+
+The per-org unique constraints on services (uq_service_name_org / route) and the
+document_templates check_user_requires_org constraint no longer fit the
+multi-scope model and are dropped. DROP ... IF EXISTS keeps this idempotent.
+"""
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = '008'
+down_revision: Union[str, None] = '007'
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+_ARRAY = postgresql.ARRAY(sa.String(100))
+
+
+def upgrade() -> None:
+    # 1. Add multi-scope array columns (NOT NULL, default empty array).
+    for table in ("services", "document_templates"):
+        op.add_column(
+            table,
+            sa.Column(
+                "allowed_organization_ids", _ARRAY,
+                nullable=False, server_default="{}",
+            ),
+        )
+        op.add_column(
+            table,
+            sa.Column(
+                "allowed_user_ids", _ARRAY,
+                nullable=False, server_default="{}",
+            ),
+        )
+
+    # 2. Backfill existing single-scope values into the new lists.
+    op.execute(
+        "UPDATE services SET allowed_organization_ids = ARRAY[organization_id] "
+        "WHERE organization_id IS NOT NULL AND organization_id <> ''"
+    )
+    op.execute(
+        "UPDATE document_templates SET allowed_organization_ids = ARRAY[organization_id] "
+        "WHERE organization_id IS NOT NULL AND organization_id <> ''"
+    )
+    op.execute(
+        "UPDATE document_templates SET allowed_user_ids = ARRAY[user_id] "
+        "WHERE user_id IS NOT NULL AND user_id <> ''"
+    )
+
+    # 3. Drop constraints that no longer fit the multi-scope model.
+    op.execute("ALTER TABLE services DROP CONSTRAINT IF EXISTS uq_service_name_org")
+    op.execute("ALTER TABLE services DROP CONSTRAINT IF EXISTS uq_service_route_org")
+    op.execute("ALTER TABLE document_templates DROP CONSTRAINT IF EXISTS check_user_requires_org")
+
+    # 4. Indexes: plain index on services.name + GIN indexes for array membership.
+    op.create_index("idx_services_name", "services", ["name"])
+    op.create_index(
+        "idx_services_allowed_orgs", "services",
+        ["allowed_organization_ids"], postgresql_using="gin",
+    )
+    op.create_index(
+        "idx_services_allowed_users", "services",
+        ["allowed_user_ids"], postgresql_using="gin",
+    )
+    op.create_index(
+        "idx_templates_allowed_orgs", "document_templates",
+        ["allowed_organization_ids"], postgresql_using="gin",
+    )
+    op.create_index(
+        "idx_templates_allowed_users", "document_templates",
+        ["allowed_user_ids"], postgresql_using="gin",
+    )
+
+    # 5. Service <-> document template junction table.
+    op.create_table(
+        "service_document_templates",
+        sa.Column(
+            "service_id", postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("services.id", ondelete="CASCADE"), primary_key=True,
+        ),
+        sa.Column(
+            "document_template_id", postgresql.UUID(as_uuid=True),
+            sa.ForeignKey("document_templates.id", ondelete="CASCADE"), primary_key=True,
+        ),
+    )
+    op.create_index(
+        "idx_service_document_templates_template",
+        "service_document_templates", ["document_template_id"],
+    )
+
+
+def downgrade() -> None:
+    # Reverse order. Backfilled list data is lost; legacy scalar columns remain.
+    op.drop_index("idx_service_document_templates_template", table_name="service_document_templates")
+    op.drop_table("service_document_templates")
+
+    op.drop_index("idx_templates_allowed_users", table_name="document_templates")
+    op.drop_index("idx_templates_allowed_orgs", table_name="document_templates")
+    op.drop_index("idx_services_allowed_users", table_name="services")
+    op.drop_index("idx_services_allowed_orgs", table_name="services")
+    op.drop_index("idx_services_name", table_name="services")
+
+    # Re-add the dropped constraints (best-effort on downgrade).
+    op.execute(
+        "ALTER TABLE document_templates ADD CONSTRAINT check_user_requires_org "
+        "CHECK ((user_id IS NULL) OR (organization_id IS NOT NULL))"
+    )
+    op.create_unique_constraint("uq_service_route_org", "services", ["route", "organization_id"])
+    op.create_unique_constraint("uq_service_name_org", "services", ["name", "organization_id"])
+
+    for table in ("document_templates", "services"):
+        op.drop_column(table, "allowed_user_ids")
+        op.drop_column(table, "allowed_organization_ids")

--- a/app/models/__init__.py
+++ b/app/models/__init__.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python3
 from app.core.database import Base
+from .associations import service_document_templates
 from .organization import Organization
 from .provider import Provider
 from .model import Model
@@ -17,6 +18,7 @@ from .prompt_type import PromptType
 
 __all__ = [
     "Base",
+    "service_document_templates",
     "Organization",
     "Provider",
     "Model",

--- a/app/models/associations.py
+++ b/app/models/associations.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+"""Association tables shared between models."""
+from sqlalchemy import Column, ForeignKey, Table, Index
+from sqlalchemy.dialects.postgresql import UUID
+from app.core.database import Base
+
+# Many-to-many link between services and the document templates available for them.
+# When a service has no rows here, the available set falls back to the global
+# default template (see document_template_service.get_default_template).
+service_document_templates = Table(
+    "service_document_templates",
+    Base.metadata,
+    Column(
+        "service_id",
+        UUID(as_uuid=True),
+        ForeignKey("services.id", ondelete="CASCADE"),
+        primary_key=True,
+    ),
+    Column(
+        "document_template_id",
+        UUID(as_uuid=True),
+        ForeignKey("document_templates.id", ondelete="CASCADE"),
+        primary_key=True,
+    ),
+    Index("idx_service_document_templates_template", "document_template_id"),
+)

--- a/app/models/document_template.py
+++ b/app/models/document_template.py
@@ -2,8 +2,8 @@
 """DocumentTemplate model for document generation templates."""
 import uuid
 from typing import Literal
-from sqlalchemy import Column, String, DateTime, Integer, Boolean, Text, Index, CheckConstraint
-from sqlalchemy.dialects.postgresql import UUID, JSONB
+from sqlalchemy import Column, String, DateTime, Integer, Boolean, Text, Index
+from sqlalchemy.dialects.postgresql import UUID, JSONB, ARRAY
 from sqlalchemy.sql import func
 from app.core.database import Base
 
@@ -11,10 +11,13 @@ from app.core.database import Base
 class DocumentTemplate(Base):
     """Document template for generating DOCX/PDF from job results.
 
-    Visibility hierarchy:
-    - System templates: organization_id=NULL, user_id=NULL (visible to all)
-    - Organization templates: organization_id=X, user_id=NULL (visible to org X)
-    - User templates: organization_id=X, user_id=Y (visible only to user Y)
+    Visibility (multi-scope):
+    - System templates: allowed_organization_ids=[], allowed_user_ids=[] (visible to all)
+    - Organization templates: caller org in allowed_organization_ids
+    - User templates: caller user in allowed_user_ids
+    The legacy single organization_id/user_id columns are kept for backward
+    compatibility (derived from the lists) and the `scope` string is derived
+    from the lists.
     """
 
     __tablename__ = "document_templates"
@@ -41,6 +44,15 @@ class DocumentTemplate(Base):
         String(100),
         nullable=True,
         index=True
+    )
+
+    # Multi-scope access lists (free-form external IDs, no FK). Both empty =>
+    # system template (visible to all). Mirror of the Service scoping model.
+    allowed_organization_ids = Column(
+        ARRAY(String(100)), nullable=False, server_default='{}'
+    )
+    allowed_user_ids = Column(
+        ARRAY(String(100)), nullable=False, server_default='{}'
     )
 
     # File information
@@ -78,21 +90,31 @@ class DocumentTemplate(Base):
         Index("idx_templates_user_id", "user_id"),
         Index("idx_templates_scope", "organization_id", "user_id"),
         Index("idx_templates_file_hash", "file_hash"),
-        # Constraint: user_id requires organization_id
-        CheckConstraint(
-            "(user_id IS NULL) OR (organization_id IS NOT NULL)",
-            name="check_user_requires_org"
+        Index(
+            "idx_templates_allowed_orgs",
+            "allowed_organization_ids",
+            postgresql_using="gin",
+        ),
+        Index(
+            "idx_templates_allowed_users",
+            "allowed_user_ids",
+            postgresql_using="gin",
         ),
     )
 
     @property
     def scope(self) -> Literal['system', 'organization', 'user']:
-        """Return scope level: system, organization, or user."""
-        if self.organization_id is None and self.user_id is None:
+        """Return scope level derived from the access lists.
+
+        - both lists empty -> system
+        - any user listed   -> user
+        - otherwise         -> organization
+        """
+        if not self.allowed_organization_ids and not self.allowed_user_ids:
             return "system"
-        elif self.user_id is None:
-            return "organization"
-        return "user"
+        if self.allowed_user_ids:
+            return "user"
+        return "organization"
 
     def __repr__(self) -> str:
         return f"<DocumentTemplate(id={self.id}, name_fr={self.name_fr}, scope={self.scope})>"

--- a/app/models/service.py
+++ b/app/models/service.py
@@ -1,13 +1,14 @@
 #!/usr/bin/env python3
 import uuid
 from sqlalchemy import (
-    Column, String, DateTime, ForeignKey, Boolean, Index, UniqueConstraint
+    Column, String, DateTime, ForeignKey, Boolean, Index
 )
-from sqlalchemy.dialects.postgresql import UUID, JSONB
+from sqlalchemy.dialects.postgresql import UUID, JSONB, ARRAY
 from sqlalchemy.orm import relationship
 from sqlalchemy.sql import func
 from typing import TYPE_CHECKING
 from app.core.database import Base
+from app.models.associations import service_document_templates
 
 if TYPE_CHECKING:
     pass
@@ -23,8 +24,19 @@ class Service(Base):
     route = Column(String(100), nullable=False, index=True)
     service_type = Column(String(50), nullable=False, index=True)
     description = Column(JSONB, nullable=False, default={}, server_default='{}')
-    # Free-form organization identifier (no FK constraint)
+    # Legacy single-org identifier (no FK constraint). Kept for backward compat:
+    # populated/derived from allowed_organization_ids, still returned to clients
+    # that read a single organization_id (e.g. LinTO Studio).
     organization_id = Column(String(100), nullable=True, index=True)
+    # Multi-scope access lists (free-form external IDs, no FK). A service is
+    # visible if the caller's org is in allowed_organization_ids OR the caller's
+    # user is in allowed_user_ids OR both lists are empty (= global service).
+    allowed_organization_ids = Column(
+        ARRAY(String(100)), nullable=False, server_default='{}'
+    )
+    allowed_user_ids = Column(
+        ARRAY(String(100)), nullable=False, server_default='{}'
+    )
     is_active = Column(Boolean, default=True, nullable=False, index=True)
     service_metadata = Column("metadata", JSONB, default={}, nullable=False, server_default='{}')
     
@@ -57,17 +69,35 @@ class Service(Base):
         cascade="all, delete-orphan"
     )
     jobs = relationship("Job", back_populates="service", passive_deletes=True)
-    # Note: templates relationship removed in migration 002
-    # Templates are now scoped by organization/user, not service
+    # Document templates explicitly made available for this service. Empty set =>
+    # fall back to the global default template (see get_service_templates).
+    document_templates = relationship(
+        "DocumentTemplate",
+        secondary=service_document_templates,
+        lazy="selectin",
+    )
 
     # Constraints (service_type validation moved to lookup table)
+    # Note: per-org unique constraints on (name) / (route) were dropped when
+    # services gained multi-org/user scoping (no single scalar scope to key on).
+    # Studio resolves services by first name/route match, so admins keep these
+    # unique; plain indexes below speed lookups.
     __table_args__ = (
-        UniqueConstraint("name", "organization_id", name="uq_service_name_org"),
-        UniqueConstraint("route", "organization_id", name="uq_service_route_org"),
         Index("idx_services_org", "organization_id"),
         Index("idx_services_type", "service_type"),
         Index("idx_services_active", "is_active"),
         Index("idx_services_route", "route"),
+        Index("idx_services_name", "name"),
+        Index(
+            "idx_services_allowed_orgs",
+            "allowed_organization_ids",
+            postgresql_using="gin",
+        ),
+        Index(
+            "idx_services_allowed_users",
+            "allowed_user_ids",
+            postgresql_using="gin",
+        ),
     )
 
     def __repr__(self) -> str:

--- a/app/schemas/service.py
+++ b/app/schemas/service.py
@@ -320,7 +320,10 @@ class ServiceBase(BaseModel):
     route: str = Field(..., min_length=1, max_length=100)
     service_type: str = Field(..., min_length=1, max_length=50)
     description: Dict[str, str] = Field(default_factory=dict)
-    # Free-form organization identifier (any string up to 100 chars)
+    # Multi-scope access lists (free-form external IDs). Both empty => global.
+    allowed_organization_ids: List[str] = Field(default_factory=list)
+    allowed_user_ids: List[str] = Field(default_factory=list)
+    # Legacy single-org identifier, derived from the lists for backward compat.
     organization_id: Optional[str] = Field(None, max_length=100)
     is_active: bool = True
     metadata: Dict[str, Any] = Field(default_factory=dict)
@@ -335,12 +338,16 @@ class ServiceCreate(BaseModel):
     route: Optional[str] = Field(None, min_length=1, max_length=100)  # Auto-generated from name if not provided
     service_type: str = Field(..., min_length=1, max_length=50)
     description: Dict[str, str] = Field(default_factory=dict)
-    # Free-form organization identifier (any string up to 100 chars)
-    organization_id: Optional[str] = Field(None, max_length=100)
+    # Multi-scope access lists (free-form external IDs). Both empty => global.
+    allowed_organization_ids: List[str] = Field(default_factory=list)
+    allowed_user_ids: List[str] = Field(default_factory=list)
+    # Deprecated single-org alias (folded into the lists by the service layer).
+    organization_id: Optional[str] = Field(None, max_length=100, deprecated=True)
     is_active: bool = True
     metadata: Dict[str, Any] = Field(default_factory=dict)
     service_category: Optional[str] = Field(None, max_length=50)
     flavors: List[ServiceFlavorCreate] = Field(default_factory=list)  # Optional, can be added later
+    template_ids: Optional[List[UUID]] = Field(None, description="Document templates available for this service")
 
 
 class ServiceUpdate(BaseModel):
@@ -349,12 +356,16 @@ class ServiceUpdate(BaseModel):
     route: Optional[str] = Field(None, min_length=1, max_length=100)
     service_type: Optional[str] = None
     description: Optional[Dict[str, str]] = None
-    organization_id: Optional[str] = Field(None, max_length=100)
+    # When provided, replaces the service's access lists.
+    allowed_organization_ids: Optional[List[str]] = None
+    allowed_user_ids: Optional[List[str]] = None
+    organization_id: Optional[str] = Field(None, max_length=100, deprecated=True)
     is_active: Optional[bool] = None
     flavors: Optional[List[ServiceFlavorCreate]] = None
     metadata: Optional[Dict[str, Any]] = None
     service_category: Optional[str] = Field(None, max_length=50)
     default_template_id: Optional[UUID] = Field(None, description="Default document template for export")
+    template_ids: Optional[List[UUID]] = Field(None, description="Document templates available for this service")
 
 
 class ServiceResponse(ServiceBase):
@@ -362,11 +373,19 @@ class ServiceResponse(ServiceBase):
     id: UUID
     flavors: List[ServiceFlavorResponse]
     default_template_id: Optional[UUID] = None
+    # IDs of document templates explicitly linked to this service (may be empty,
+    # in which case the global default template is used as fallback).
+    template_ids: List[UUID] = Field(default_factory=list)
     created_at: datetime
     updated_at: datetime
 
     class Config:
         from_attributes = True
+
+
+class ServiceTemplatesUpdate(BaseModel):
+    """Replace the set of document templates available for a service."""
+    template_ids: List[UUID] = Field(default_factory=list)
 
 
 class ServiceListResponse(BaseModel):

--- a/app/schemas/template.py
+++ b/app/schemas/template.py
@@ -12,17 +12,13 @@ class TemplateCreate(BaseModel):
     name_en: Optional[str] = Field(None, max_length=255)
     description_fr: Optional[str] = None
     description_en: Optional[str] = None
-    # Using str instead of UUID for flexibility with external systems
-    organization_id: Optional[str] = Field(None, max_length=100)
-    user_id: Optional[str] = Field(None, max_length=100)
+    # Multi-scope access lists (free-form external IDs). Both empty => system.
+    allowed_organization_ids: List[str] = Field(default_factory=list)
+    allowed_user_ids: List[str] = Field(default_factory=list)
+    # Deprecated single-scope aliases (folded into the lists by the service layer).
+    organization_id: Optional[str] = Field(None, max_length=100, deprecated=True)
+    user_id: Optional[str] = Field(None, max_length=100, deprecated=True)
     is_default: bool = False
-
-    @model_validator(mode='after')
-    def validate_user_requires_org(self):
-        """Validate that user_id requires organization_id."""
-        if self.user_id is not None and self.organization_id is None:
-            raise ValueError("user_id requires organization_id to be set")
-        return self
 
 
 class TemplateUpdate(BaseModel):
@@ -31,6 +27,9 @@ class TemplateUpdate(BaseModel):
     name_en: Optional[str] = Field(None, max_length=255)
     description_fr: Optional[str] = None
     description_en: Optional[str] = None
+    # Scope edit: when provided, replaces the template's access lists.
+    allowed_organization_ids: Optional[List[str]] = None
+    allowed_user_ids: Optional[List[str]] = None
     is_default: Optional[bool] = None
 
 
@@ -41,7 +40,11 @@ class TemplateResponse(BaseModel):
     name_en: Optional[str]
     description_fr: Optional[str]
     description_en: Optional[str]
-    # Using str instead of UUID for flexibility with external systems
+    # Multi-scope access lists.
+    allowed_organization_ids: List[str] = Field(default_factory=list)
+    allowed_user_ids: List[str] = Field(default_factory=list)
+    # Legacy single-scope fields, derived from the lists for backward compat
+    # (LinTO Studio reads organization_id / user_id / scope).
     organization_id: Optional[str]
     user_id: Optional[str]
     file_path: str

--- a/app/seeds/base_seed.py
+++ b/app/seeds/base_seed.py
@@ -226,7 +226,9 @@ async def get_or_create_service(
         service_type=service_type,
         description=description,
         is_active=is_active,
-        organization_id=None,
+        organization_id=None,  # legacy column
+        allowed_organization_ids=[],  # global service (visible to all)
+        allowed_user_ids=[],
     )
 
     db.add(service)

--- a/app/seeds/document_templates.py
+++ b/app/seeds/document_templates.py
@@ -117,8 +117,10 @@ async def seed_global_templates(db: AsyncSession) -> Dict[str, int]:
             name_en=template_config["name_en"],
             description_fr=template_config["description_fr"],
             description_en=template_config["description_en"],
-            organization_id=None,  # System scope
-            user_id=None,  # System scope
+            organization_id=None,  # System scope (legacy column)
+            user_id=None,  # System scope (legacy column)
+            allowed_organization_ids=[],  # System scope (visible to all)
+            allowed_user_ids=[],
             file_path=str(dest_file.relative_to(document_template_service.TEMPLATES_DIR)),
             file_name=safe_filename,
             file_size=file_size,

--- a/app/services/document_template_service.py
+++ b/app/services/document_template_service.py
@@ -10,7 +10,7 @@ from typing import Optional, List
 from uuid import UUID
 
 from sqlalchemy.ext.asyncio import AsyncSession
-from sqlalchemy import select, update, or_, and_
+from sqlalchemy import select, update, or_, and_, func
 from fastapi import UploadFile
 
 from app.models.document_template import DocumentTemplate
@@ -45,6 +45,55 @@ class DocumentTemplateService:
         # Ensure templates directory exists
         self.TEMPLATES_DIR.mkdir(parents=True, exist_ok=True)
 
+    @staticmethod
+    def _normalize_ids(ids: Optional[List[str]]) -> List[str]:
+        """Strip, drop blanks/dupes and sort a list of free-form IDs (stable equality)."""
+        if not ids:
+            return []
+        seen = []
+        for raw in ids:
+            if raw is None:
+                continue
+            val = str(raw).strip()
+            if val and val not in seen:
+                seen.append(val)
+        return sorted(seen)
+
+    @classmethod
+    def _resolve_scope_lists(
+        cls,
+        allowed_organization_ids: Optional[List[str]],
+        allowed_user_ids: Optional[List[str]],
+        organization_id_alias: Optional[str] = None,
+        user_id_alias: Optional[str] = None,
+    ) -> tuple[List[str], List[str]]:
+        """Build the effective (orgs, users) access lists.
+
+        The deprecated single organization_id/user_id aliases are folded in only
+        when the explicit lists are empty, preserving backward compatibility.
+        """
+        orgs = cls._normalize_ids(allowed_organization_ids)
+        users = cls._normalize_ids(allowed_user_ids)
+        if not orgs and organization_id_alias:
+            orgs = cls._normalize_ids([organization_id_alias])
+        if not users and user_id_alias:
+            users = cls._normalize_ids([user_id_alias])
+        return orgs, users
+
+    @staticmethod
+    def _derive_legacy_scope(
+        orgs: List[str], users: List[str]
+    ) -> tuple[Optional[str], Optional[str]]:
+        """Derive the legacy single organization_id/user_id from the access lists.
+
+        Kept so clients that read a single scope (LinTO Studio) keep working.
+        """
+        if not orgs and not users:
+            return None, None
+        if users:
+            return (orgs[0] if orgs else None), users[0]
+        return orgs[0], None
+
     async def create_template(
         self,
         db: AsyncSession,
@@ -53,6 +102,8 @@ class DocumentTemplateService:
         name_en: Optional[str] = None,
         description_fr: Optional[str] = None,
         description_en: Optional[str] = None,
+        allowed_organization_ids: Optional[List[str]] = None,
+        allowed_user_ids: Optional[List[str]] = None,
         organization_id: Optional[str] = None,
         user_id: Optional[str] = None,
         is_default: bool = False,
@@ -67,19 +118,22 @@ class DocumentTemplateService:
             name_en: English name (optional)
             description_fr: French description (optional)
             description_en: English description (optional)
-            organization_id: Organization scope (NULL for system) - any string ID
-            user_id: User scope (NULL for org/system) - any string ID
+            allowed_organization_ids: Orgs allowed to see the template (empty => system)
+            allowed_user_ids: Users allowed to see the template
+            organization_id: Deprecated single-org alias (folded into the lists)
+            user_id: Deprecated single-user alias (folded into the lists)
             is_default: Whether to set as default
 
         Returns:
             Created DocumentTemplate
 
         Raises:
-            ValueError: If file is invalid or scope validation fails
+            ValueError: If file is invalid
         """
-        # Validate scope: user_id requires organization_id
-        if user_id is not None and organization_id is None:
-            raise ValueError("user_id requires organization_id to be set")
+        orgs, users = self._resolve_scope_lists(
+            allowed_organization_ids, allowed_user_ids, organization_id, user_id
+        )
+        legacy_org, legacy_user = self._derive_legacy_scope(orgs, users)
 
         # Validate file
         content = await file.read()
@@ -97,13 +151,13 @@ class DocumentTemplateService:
         # Generate unique file path
         template_id = uuid_lib.uuid4()
 
-        # Determine storage directory based on scope
-        if organization_id is None:
+        # Determine storage directory based on derived scope (cosmetic grouping)
+        if legacy_org is None:
             storage_dir = self.TEMPLATES_DIR / "global"
-        elif user_id is None:
-            storage_dir = self.TEMPLATES_DIR / f"org_{organization_id}"
+        elif legacy_user is None:
+            storage_dir = self.TEMPLATES_DIR / f"org_{legacy_org}"
         else:
-            storage_dir = self.TEMPLATES_DIR / f"org_{organization_id}" / f"user_{user_id}"
+            storage_dir = self.TEMPLATES_DIR / f"org_{legacy_org}" / f"user_{legacy_user}"
 
         storage_dir.mkdir(parents=True, exist_ok=True)
 
@@ -120,7 +174,7 @@ class DocumentTemplateService:
 
         # If setting as default, unset any existing default at the same scope
         if is_default:
-            await self._clear_default_for_scope(db, organization_id, user_id)
+            await self._clear_default_for_scope(db, orgs, users)
 
         # Create database record
         template = DocumentTemplate(
@@ -129,8 +183,10 @@ class DocumentTemplateService:
             name_en=name_en,
             description_fr=description_fr,
             description_en=description_en,
-            organization_id=organization_id,
-            user_id=user_id,
+            allowed_organization_ids=orgs,
+            allowed_user_ids=users,
+            organization_id=legacy_org,
+            user_id=legacy_user,
             file_path=str(file_path.relative_to(self.TEMPLATES_DIR)),
             file_name=safe_filename,
             file_size=len(content),
@@ -192,31 +248,20 @@ class DocumentTemplateService:
 
         conditions = []
 
-        # Always include system templates if requested
+        # System templates: both access lists empty.
         if include_system:
-            conditions.append(
-                and_(
-                    DocumentTemplate.organization_id.is_(None),
-                    DocumentTemplate.user_id.is_(None)
-                )
-            )
+            conditions.append(self._is_system_template())
 
-        # Include org templates if org_id provided
+        # Org templates: caller org is in allowed_organization_ids.
         if organization_id:
             conditions.append(
-                and_(
-                    DocumentTemplate.organization_id == organization_id,
-                    DocumentTemplate.user_id.is_(None)
-                )
+                DocumentTemplate.allowed_organization_ids.any(organization_id)
             )
 
-        # Include user templates if both provided
-        if organization_id and user_id:
+        # User templates: caller user is in allowed_user_ids.
+        if user_id:
             conditions.append(
-                and_(
-                    DocumentTemplate.organization_id == organization_id,
-                    DocumentTemplate.user_id == user_id
-                )
+                DocumentTemplate.allowed_user_ids.any(user_id)
             )
 
         # If no conditions, return empty list
@@ -228,6 +273,14 @@ class DocumentTemplateService:
         result = await db.execute(query)
         return list(result.scalars().all())
 
+    @staticmethod
+    def _is_system_template():
+        """SQLAlchemy condition: template visible to everyone (both lists empty)."""
+        return and_(
+            func.cardinality(DocumentTemplate.allowed_organization_ids) == 0,
+            func.cardinality(DocumentTemplate.allowed_user_ids) == 0,
+        )
+
     async def update_template(
         self,
         db: AsyncSession,
@@ -237,10 +290,12 @@ class DocumentTemplateService:
         name_en: Optional[str] = None,
         description_fr: Optional[str] = None,
         description_en: Optional[str] = None,
+        allowed_organization_ids: Optional[List[str]] = None,
+        allowed_user_ids: Optional[List[str]] = None,
         is_default: Optional[bool] = None,
     ) -> Optional[DocumentTemplate]:
         """
-        Update template metadata and/or file.
+        Update template metadata, scope and/or file.
 
         Args:
             db: Database session
@@ -250,6 +305,8 @@ class DocumentTemplateService:
             name_en: New English name (optional)
             description_fr: New French description (optional)
             description_en: New English description (optional)
+            allowed_organization_ids: Replace the org access list (optional)
+            allowed_user_ids: Replace the user access list (optional)
             is_default: Set as default (optional)
 
         Returns:
@@ -268,6 +325,21 @@ class DocumentTemplateService:
             template.description_fr = description_fr
         if description_en is not None:
             template.description_en = description_en
+
+        # Update scope (access lists) if either list was provided
+        if allowed_organization_ids is not None or allowed_user_ids is not None:
+            orgs, users = self._resolve_scope_lists(
+                allowed_organization_ids
+                if allowed_organization_ids is not None
+                else template.allowed_organization_ids,
+                allowed_user_ids
+                if allowed_user_ids is not None
+                else template.allowed_user_ids,
+            )
+            template.allowed_organization_ids = orgs
+            template.allowed_user_ids = users
+            # Keep legacy single-scope columns in sync for backward compat.
+            template.organization_id, template.user_id = self._derive_legacy_scope(orgs, users)
 
         # Handle file update
         if file:
@@ -307,7 +379,9 @@ class DocumentTemplateService:
         if is_default is not None and is_default != template.is_default:
             if is_default:
                 # Clear existing default at same scope
-                await self._clear_default_for_scope(db, template.organization_id, template.user_id)
+                await self._clear_default_for_scope(
+                    db, template.allowed_organization_ids, template.allowed_user_ids
+                )
             template.is_default = is_default
 
         await db.flush()
@@ -364,15 +438,14 @@ class DocumentTemplateService:
             Default DocumentTemplate or None
         """
         # First try user-level default
-        if organization_id and user_id:
+        if user_id:
             result = await db.execute(
                 select(DocumentTemplate).where(
-                    DocumentTemplate.organization_id == organization_id,
-                    DocumentTemplate.user_id == user_id,
+                    DocumentTemplate.allowed_user_ids.any(user_id),
                     DocumentTemplate.is_default.is_(True)
                 )
             )
-            template = result.scalar_one_or_none()
+            template = result.scalars().first()
             if template:
                 return template
 
@@ -380,24 +453,22 @@ class DocumentTemplateService:
         if organization_id:
             result = await db.execute(
                 select(DocumentTemplate).where(
-                    DocumentTemplate.organization_id == organization_id,
-                    DocumentTemplate.user_id.is_(None),
+                    DocumentTemplate.allowed_organization_ids.any(organization_id),
                     DocumentTemplate.is_default.is_(True)
                 )
             )
-            template = result.scalar_one_or_none()
+            template = result.scalars().first()
             if template:
                 return template
 
-        # Finally try system-level default
+        # Finally try system-level default (both access lists empty)
         result = await db.execute(
             select(DocumentTemplate).where(
-                DocumentTemplate.organization_id.is_(None),
-                DocumentTemplate.user_id.is_(None),
+                self._is_system_template(),
                 DocumentTemplate.is_default.is_(True)
             )
         )
-        return result.scalar_one_or_none()
+        return result.scalars().first()
 
     def extract_placeholders(self, file_path: Path) -> List[str]:
         """
@@ -484,43 +555,25 @@ class DocumentTemplateService:
     async def _clear_default_for_scope(
         self,
         db: AsyncSession,
-        organization_id: Optional[str],
-        user_id: Optional[str],
+        allowed_organization_ids: List[str],
+        allowed_user_ids: List[str],
     ) -> None:
-        """Clear is_default flag for all templates at the same scope."""
-        if organization_id is None and user_id is None:
-            # System scope
-            await db.execute(
-                update(DocumentTemplate)
-                .where(
-                    DocumentTemplate.organization_id.is_(None),
-                    DocumentTemplate.user_id.is_(None),
-                    DocumentTemplate.is_default.is_(True)
-                )
-                .values(is_default=False)
+        """Clear is_default flag for all templates sharing the exact same scope.
+
+        Scope identity is the pair of (sorted) access lists, so only one template
+        is the default within a given audience.
+        """
+        orgs = self._normalize_ids(allowed_organization_ids)
+        users = self._normalize_ids(allowed_user_ids)
+        await db.execute(
+            update(DocumentTemplate)
+            .where(
+                DocumentTemplate.allowed_organization_ids == orgs,
+                DocumentTemplate.allowed_user_ids == users,
+                DocumentTemplate.is_default.is_(True)
             )
-        elif user_id is None:
-            # Organization scope
-            await db.execute(
-                update(DocumentTemplate)
-                .where(
-                    DocumentTemplate.organization_id == organization_id,
-                    DocumentTemplate.user_id.is_(None),
-                    DocumentTemplate.is_default.is_(True)
-                )
-                .values(is_default=False)
-            )
-        else:
-            # User scope
-            await db.execute(
-                update(DocumentTemplate)
-                .where(
-                    DocumentTemplate.organization_id == organization_id,
-                    DocumentTemplate.user_id == user_id,
-                    DocumentTemplate.is_default.is_(True)
-                )
-                .values(is_default=False)
-            )
+            .values(is_default=False)
+        )
 
     def _sanitize_filename(self, filename: str) -> str:
         """Sanitize filename to prevent path traversal."""
@@ -610,14 +663,20 @@ class DocumentTemplateService:
         file_size = dest_path.stat().st_size
 
         # Create new template record
+        orgs, users = self._resolve_scope_lists(
+            None, None, target_organization_id, target_user_id
+        )
+        legacy_org, legacy_user = self._derive_legacy_scope(orgs, users)
         new_template = DocumentTemplate(
             id=new_id,
             name_fr=new_name_fr or source.name_fr,
             name_en=new_name_en or source.name_en,
             description_fr=source.description_fr,
             description_en=source.description_en,
-            organization_id=target_organization_id,
-            user_id=target_user_id,
+            allowed_organization_ids=orgs,
+            allowed_user_ids=users,
+            organization_id=legacy_org,
+            user_id=legacy_user,
             file_path=str(dest_path.relative_to(self.TEMPLATES_DIR)),
             file_name=safe_filename,
             file_size=file_size,

--- a/app/services/service_service.py
+++ b/app/services/service_service.py
@@ -22,6 +22,39 @@ logger = logging.getLogger(__name__)
 class ServiceService:
     """Service layer for service business logic."""
 
+    @staticmethod
+    def _is_global_service():
+        """SQLAlchemy condition: service visible to everyone (no scope restrictions)."""
+        return and_(
+            func.cardinality(Service.allowed_organization_ids) == 0,
+            func.cardinality(Service.allowed_user_ids) == 0,
+            or_(Service.organization_id.is_(None), Service.organization_id == ""),
+        )
+
+    @staticmethod
+    def _normalize_ids(ids) -> list:
+        """Strip, drop blanks/dupes and sort a list of free-form IDs (stable equality)."""
+        if not ids:
+            return []
+        seen = []
+        for raw in ids:
+            if raw is None:
+                continue
+            val = str(raw).strip()
+            if val and val not in seen:
+                seen.append(val)
+        return sorted(seen)
+
+    @classmethod
+    def _resolve_scope_lists(cls, allowed_organization_ids, allowed_user_ids,
+                             organization_id_alias=None):
+        """Build effective (orgs, users) lists, folding the deprecated org alias in."""
+        orgs = cls._normalize_ids(allowed_organization_ids)
+        users = cls._normalize_ids(allowed_user_ids)
+        if not orgs and organization_id_alias:
+            orgs = cls._normalize_ids([organization_id_alias])
+        return orgs, users
+
     async def _load_prompt_contents(
         self,
         db: AsyncSession,
@@ -166,11 +199,14 @@ class ServiceService:
             "route": service.route,
             "service_type": service.service_type,
             "description": service.description,
+            "allowed_organization_ids": list(service.allowed_organization_ids or []),
+            "allowed_user_ids": list(service.allowed_user_ids or []),
             "organization_id": service.organization_id,
             "is_active": service.is_active,
             "metadata": service.service_metadata,  # Map service_metadata -> metadata
             "service_category": service.service_category,
             "default_template_id": service.default_template_id,
+            "template_ids": [t.id for t in (service.document_templates or [])],
             "flavors": [self._to_flavor_response(f) for f in service.flavors],
             "created_at": service.created_at,
             "updated_at": service.updated_at
@@ -224,13 +260,23 @@ class ServiceService:
             # Convert name to URL-friendly route (lowercase, replace spaces with hyphens)
             route = request.name.lower().replace(' ', '-').replace('_', '-')
 
+        # Resolve multi-scope access lists (fold deprecated organization_id alias)
+        orgs, users = self._resolve_scope_lists(
+            request.allowed_organization_ids,
+            request.allowed_user_ids,
+            request.organization_id,
+        )
+
         # Create service
         service = Service(
             name=request.name,
             route=route,
             service_type=request.service_type,
             description=request.description or {},
-            organization_id=request.organization_id,
+            allowed_organization_ids=orgs,
+            allowed_user_ids=users,
+            # Keep legacy single-org column in sync for backward compat.
+            organization_id=(orgs[0] if len(orgs) == 1 and not users else None),
             is_active=request.is_active,
             metadata=request.metadata or {}
         )
@@ -239,6 +285,10 @@ class ServiceService:
 
         try:
             await db.flush()
+
+            # Link available document templates if provided
+            if request.template_ids is not None:
+                await self._apply_template_links(db, service, request.template_ids)
 
             # Create flavors
             for flavor_data in request.flavors:
@@ -300,6 +350,7 @@ class ServiceService:
         service_type: Optional[str] = None,
         is_active: Optional[bool] = None,
         organization_id: Optional[str] = None,
+        user_id: Optional[str] = None,
         skip: int = 0,
         limit: int = 100
     ) -> ServiceListResponse:
@@ -310,7 +361,8 @@ class ServiceService:
             db: Database session
             service_type: Filter by service type
             is_active: Filter by active status
-            organization_id: Filter by organization
+            organization_id: Visibility filter by organization
+            user_id: Visibility filter by user
             skip: Pagination offset
             limit: Page size
 
@@ -325,14 +377,19 @@ class ServiceService:
             filters.append(Service.service_type == service_type)
         if is_active is not None:
             filters.append(Service.is_active == is_active)
-        if organization_id:
-            # Visibility filter: show global services (no org) + services for this org
-            # Services with a different organization_id are excluded
-            filters.append(or_(
-                Service.organization_id.is_(None),
-                Service.organization_id == "",
-                Service.organization_id == organization_id
-            ))
+        if organization_id or user_id:
+            # Visibility filter: a service is visible when it is global (no scope
+            # restrictions) OR the caller's org/user is in its access lists.
+            visibility = [self._is_global_service()]
+            if organization_id:
+                visibility.append(
+                    Service.allowed_organization_ids.any(organization_id)
+                )
+                # Legacy single-org fallback (pre-migration / external writers)
+                visibility.append(Service.organization_id == organization_id)
+            if user_id:
+                visibility.append(Service.allowed_user_ids.any(user_id))
+            filters.append(or_(*visibility))
 
         if filters:
             query = query.where(and_(*filters))
@@ -412,10 +469,35 @@ class ServiceService:
                 detail="Service not found"
             )
 
-        # Update service fields if provided
-        update_data = request.model_dump(exclude_unset=True, exclude={"flavors"})
+        # Update scope (access lists) if provided. Handled explicitly so we can
+        # normalize, fold the deprecated organization_id alias, and keep the
+        # legacy single-org column in sync.
+        provided = request.model_dump(exclude_unset=True)
+        scope_touched = any(
+            k in provided for k in ("allowed_organization_ids", "allowed_user_ids", "organization_id")
+        )
+        if scope_touched:
+            orgs, users = self._resolve_scope_lists(
+                provided.get("allowed_organization_ids", service.allowed_organization_ids),
+                provided.get("allowed_user_ids", service.allowed_user_ids),
+                provided.get("organization_id"),
+            )
+            service.allowed_organization_ids = orgs
+            service.allowed_user_ids = users
+            service.organization_id = orgs[0] if len(orgs) == 1 and not users else None
+
+        # Update remaining scalar fields (scope + relationship handled separately)
+        update_data = request.model_dump(
+            exclude_unset=True,
+            exclude={"flavors", "template_ids", "allowed_organization_ids",
+                     "allowed_user_ids", "organization_id"},
+        )
         for field, value in update_data.items():
             setattr(service, field, value)
+
+        # Replace linked document templates if provided
+        if request.template_ids is not None:
+            await self._apply_template_links(db, service, request.template_ids)
 
         # Update flavors if provided
         if request.flavors is not None:
@@ -518,6 +600,99 @@ class ServiceService:
         await db.delete(service)
         await db.flush()
         logger.info(f"Deleted service: {service_id}")
+
+    async def _apply_template_links(self, db: AsyncSession, service: Service, template_ids) -> None:
+        """Replace the set of document templates available for a service.
+
+        Validates that every id exists, then sets the relationship wholesale.
+        """
+        from app.models.document_template import DocumentTemplate
+
+        ids = list(dict.fromkeys(template_ids or []))  # dedupe, preserve order
+        if not ids:
+            service.document_templates = []
+            return
+
+        result = await db.execute(
+            select(DocumentTemplate).where(DocumentTemplate.id.in_(ids))
+        )
+        templates = list(result.scalars().all())
+        found = {t.id for t in templates}
+        missing = [str(tid) for tid in ids if tid not in found]
+        if missing:
+            raise HTTPException(
+                status_code=404,
+                detail=f"Document template(s) not found: {', '.join(missing)}"
+            )
+        service.document_templates = templates
+
+    async def set_service_templates(
+        self, db: AsyncSession, service_id: UUID, template_ids
+    ) -> ServiceResponse:
+        """Replace the linked templates for a service and return the service."""
+        result = await db.execute(
+            select(Service)
+            .options(*self._get_flavor_load_options())
+            .where(Service.id == service_id)
+        )
+        service = result.scalar_one_or_none()
+        if not service:
+            raise HTTPException(status_code=404, detail="Service not found")
+
+        await self._apply_template_links(db, service, template_ids)
+        await db.flush()
+
+        result = await db.execute(
+            select(Service)
+            .options(*self._get_flavor_load_options())
+            .where(Service.id == service_id)
+        )
+        service = result.unique().scalar_one()
+        logger.info(f"Updated template links for service {service_id}: {len(template_ids or [])} templates")
+        return self._to_response(service)
+
+    async def get_service_templates(
+        self,
+        db: AsyncSession,
+        service_id: UUID,
+        organization_id: Optional[str] = None,
+        user_id: Optional[str] = None,
+    ):
+        """Return the document templates available for a service.
+
+        - If the service has explicitly linked templates: those, filtered by the
+          caller's visibility scope (org/user/system).
+        - If it has no links: fall back to the global default template (if any).
+        Raises 404 if the service does not exist.
+        """
+        from app.services.document_template_service import document_template_service
+
+        result = await db.execute(
+            select(Service)
+            .options(selectinload(Service.document_templates))
+            .where(Service.id == service_id)
+        )
+        service = result.scalar_one_or_none()
+        if not service:
+            raise HTTPException(status_code=404, detail="Service not found")
+
+        linked = list(service.document_templates or [])
+        if not linked:
+            # Fallback: global default template (system-scoped, is_default=True)
+            default = await document_template_service.get_default_template(db)
+            return [default] if default else []
+
+        def _visible(t) -> bool:
+            if not t.allowed_organization_ids and not t.allowed_user_ids:
+                return True  # system template, visible to all
+            if organization_id and organization_id in (t.allowed_organization_ids or []):
+                return True
+            if user_id and user_id in (t.allowed_user_ids or []):
+                return True
+            # No scope context provided => return links as-is (admin/no-filter view)
+            return organization_id is None and user_id is None
+
+        return [t for t in linked if _visible(t)]
 
 
 # Singleton instance

--- a/frontend/app/[locale]/services/[id]/templates/page.tsx
+++ b/frontend/app/[locale]/services/[id]/templates/page.tsx
@@ -1,20 +1,21 @@
 'use client';
 
-import { use, useState } from 'react';
+import { use, useEffect, useMemo, useState } from 'react';
 import { useTranslations, useLocale } from 'next-intl';
 import { Link } from '@/lib/navigation';
 import { toast } from 'sonner';
-import { ArrowLeft, FileText, Check, X, Library } from 'lucide-react';
+import { ArrowLeft, FileText, X, Library, Save } from 'lucide-react';
 
 import { Button } from '@/components/ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
 import { Badge } from '@/components/ui/badge';
+import { Checkbox } from '@/components/ui/checkbox';
 
 import { LoadingSpinner } from '@/components/shared/LoadingSpinner';
 import { ConfirmDialog } from '@/components/shared/ConfirmDialog';
 import { TemplateLibraryDialog } from '@/components/templates';
 
-import { useService, useUpdateService } from '@/hooks/use-services';
+import { useService, useUpdateService, useSetServiceTemplates } from '@/hooks/use-services';
 import { useDocumentTemplate, useDocumentTemplates } from '@/hooks/use-document-templates';
 import { getLocalizedName, getLocalizedDescription } from '@/lib/template-utils';
 
@@ -40,8 +41,38 @@ export default function ServiceTemplatesPage({ params }: PageProps) {
     service?.default_template_id ?? undefined
   );
 
+  // All templates the admin can pick from (admin view: every scope)
+  const { data: allTemplates, isLoading: allTemplatesLoading } = useDocumentTemplates({ include_all: true });
+
   // Update service mutation
   const updateService = useUpdateService();
+  const setServiceTemplates = useSetServiceTemplates();
+
+  // Local selection state for the "available templates" set, seeded from the service
+  const [selectedIds, setSelectedIds] = useState<string[]>([]);
+  useEffect(() => {
+    if (service) setSelectedIds(service.template_ids ?? []);
+  }, [service]);
+
+  const linkedDirty = useMemo(() => {
+    const current = [...(service?.template_ids ?? [])].sort().join(',');
+    const next = [...selectedIds].sort().join(',');
+    return current !== next;
+  }, [service, selectedIds]);
+
+  const toggleTemplate = (id: string) => {
+    setSelectedIds((prev) => (prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]));
+  };
+
+  const handleSaveAvailable = async () => {
+    try {
+      await setServiceTemplates.mutateAsync({ id: serviceId, templateIds: selectedIds });
+      toast.success(t('availableTemplates.saved'));
+      refetchService();
+    } catch (error: any) {
+      toast.error(error.message || tCommon('error'));
+    }
+  };
 
   const isLoading = serviceLoading || templateLoading;
 
@@ -184,6 +215,59 @@ export default function ServiceTemplatesPage({ params }: PageProps) {
                 {t('selectDefaultTemplate')}
               </Button>
             </div>
+          )}
+        </CardContent>
+      </Card>
+
+      {/* Available templates (service <-> templates links) */}
+      <Card>
+        <CardHeader>
+          <div className="flex items-center justify-between">
+            <div>
+              <CardTitle className="flex items-center gap-2">
+                <Library className="h-5 w-5" />
+                {t('availableTemplates.title')}
+              </CardTitle>
+              <CardDescription>{t('availableTemplates.description')}</CardDescription>
+            </div>
+            <Button onClick={handleSaveAvailable} disabled={!linkedDirty || setServiceTemplates.isPending}>
+              <Save className="h-4 w-4 mr-2" />
+              {t('availableTemplates.save')}
+            </Button>
+          </div>
+        </CardHeader>
+        <CardContent>
+          {allTemplatesLoading ? (
+            <LoadingSpinner />
+          ) : !allTemplates || allTemplates.length === 0 ? (
+            <p className="text-sm text-muted-foreground">{tTemplates('noTemplates')}</p>
+          ) : (
+            <>
+              {selectedIds.length === 0 && (
+                <p className="text-sm text-muted-foreground mb-3">{t('availableTemplates.empty')}</p>
+              )}
+              <div className="space-y-2">
+                {allTemplates.map((tpl) => (
+                  <label
+                    key={tpl.id}
+                    className="flex items-center gap-3 p-3 border rounded-lg cursor-pointer hover:bg-muted/40"
+                  >
+                    <Checkbox
+                      checked={selectedIds.includes(tpl.id)}
+                      onCheckedChange={() => toggleTemplate(tpl.id)}
+                    />
+                    <FileText className="h-4 w-4 text-muted-foreground shrink-0" />
+                    <div className="min-w-0 flex-1">
+                      <p className="font-medium truncate">{getLocalizedName(tpl, locale)}</p>
+                      <p className="text-xs text-muted-foreground truncate">{tpl.file_name}</p>
+                    </div>
+                    <Badge variant="outline" className="text-xs capitalize shrink-0">
+                      {tpl.scope}
+                    </Badge>
+                  </label>
+                ))}
+              </div>
+            </>
           )}
         </CardContent>
       </Card>

--- a/frontend/components/layout/Footer.tsx
+++ b/frontend/components/layout/Footer.tsx
@@ -36,7 +36,7 @@ export function Footer() {
     <footer className="border-t bg-background">
       <div className="flex h-12 items-center justify-between px-4">
         <div className="flex items-center gap-3 text-xs text-muted-foreground">
-          <span>{t('version')}: 0.1.0</span>
+          <span>{t('version')}: {process.env.NEXT_PUBLIC_APP_VERSION}</span>
           <Separator orientation="vertical" className="h-4" />
           <div className="flex items-center gap-2">
             <span>{t('connectionStatus')}:</span>

--- a/frontend/components/services/ServiceForm.tsx
+++ b/frontend/components/services/ServiceForm.tsx
@@ -22,6 +22,7 @@ import {
   SelectValue,
 } from '@/components/ui/select';
 import { Textarea } from '@/components/ui/textarea';
+import { ScopeEditor } from '@/components/shared/ScopeEditor';
 
 import { useCreateService, useUpdateService } from '@/hooks/use-services';
 import { useServiceTypes } from '@/hooks/use-service-types';
@@ -52,7 +53,8 @@ export function ServiceForm({ service, onSuccess, onCancel }: ServiceFormProps) 
         en: service?.description.en || '',
         fr: service?.description.fr || '',
       },
-      organization_id: service?.organization_id || null,
+      allowed_organization_ids: service?.allowed_organization_ids ?? [],
+      allowed_user_ids: service?.allowed_user_ids ?? [],
       // Don't load flavors in edit mode - they are managed separately via Flavors tab
       flavors: [],
     },
@@ -67,7 +69,8 @@ export function ServiceForm({ service, onSuccess, onCancel }: ServiceFormProps) 
           data: {
             name: data.name,
             description: data.description,
-            organization_id: data.organization_id || '',
+            allowed_organization_ids: data.allowed_organization_ids ?? [],
+            allowed_user_ids: data.allowed_user_ids ?? [],
           },
         });
       } else {
@@ -93,7 +96,8 @@ export function ServiceForm({ service, onSuccess, onCancel }: ServiceFormProps) 
           name: data.name,
           service_type: data.service_type,
           description: data.description,
-          organization_id: data.organization_id || '',
+          allowed_organization_ids: data.allowed_organization_ids ?? [],
+          allowed_user_ids: data.allowed_user_ids ?? [],
           flavors: cleanedFlavors as CreateFlavorRequest[],
         };
 
@@ -195,27 +199,28 @@ export function ServiceForm({ service, onSuccess, onCancel }: ServiceFormProps) 
           )}
         />
 
-        {/* Organization ID */}
-        <FormField
-          control={form.control}
-          name="organization_id"
-          render={({ field }) => (
-            <FormItem>
-              <FormLabel>
-                {t('fields.organizationId')} <span className="text-muted-foreground text-xs">({tCommon('optional')})</span>
-              </FormLabel>
-              <FormControl>
-                <Input
-                  placeholder={t('placeholders.organizationId')}
-                  {...field}
-                  value={field.value || ''}
-                  onChange={(e) => field.onChange(e.target.value || null)}
-                />
-              </FormControl>
-              <FormMessage />
-            </FormItem>
-          )}
-        />
+        {/* Scope: allowed organizations and users (empty = global service) */}
+        <FormItem>
+          <FormLabel>
+            {t('fields.scope')}{' '}
+            <span className="text-muted-foreground text-xs">({tCommon('optional')})</span>
+          </FormLabel>
+          <ScopeEditor
+            value={{
+              organizationIds: form.watch('allowed_organization_ids') ?? [],
+              userIds: form.watch('allowed_user_ids') ?? [],
+            }}
+            onChange={(next) => {
+              form.setValue('allowed_organization_ids', next.organizationIds, { shouldDirty: true });
+              form.setValue('allowed_user_ids', next.userIds, { shouldDirty: true });
+            }}
+            orgLabel={t('fields.allowedOrganizations')}
+            userLabel={t('fields.allowedUsers')}
+            orgPlaceholder={t('placeholders.addOrganizationId')}
+            userPlaceholder={t('placeholders.addUserId')}
+            globalHint={t('scope.globalHint')}
+          />
+        </FormItem>
 
         {/* Actions */}
         <div className="flex justify-end gap-3">

--- a/frontend/components/shared/ScopeEditor.tsx
+++ b/frontend/components/shared/ScopeEditor.tsx
@@ -1,0 +1,155 @@
+'use client';
+
+import { useState, KeyboardEvent } from 'react';
+import { Plus, X, Globe } from 'lucide-react';
+
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Badge } from '@/components/ui/badge';
+import { Label } from '@/components/ui/label';
+
+export interface ScopeValue {
+  organizationIds: string[];
+  userIds: string[];
+}
+
+interface ScopeEditorProps {
+  value: ScopeValue;
+  onChange: (value: ScopeValue) => void;
+  disabled?: boolean;
+  /** Labels / hints (pass translated strings). */
+  orgLabel?: string;
+  userLabel?: string;
+  orgPlaceholder?: string;
+  userPlaceholder?: string;
+  /** Shown when both lists are empty (resource is global / system-wide). */
+  globalHint?: string;
+  className?: string;
+}
+
+/**
+ * Free-text chip editor for the multi-scope access lists (organizations + users).
+ *
+ * Org/user IDs are external free-form identifiers (e.g. Studio Mongo ObjectIds),
+ * so there is no dropdown of known values - the admin types/pastes an ID and
+ * presses Enter (or the + button) to add it. When both lists are empty the
+ * resource is global (visible to everyone).
+ */
+export function ScopeEditor({
+  value,
+  onChange,
+  disabled = false,
+  orgLabel = 'Organizations',
+  userLabel = 'Users',
+  orgPlaceholder = 'Add an organization ID…',
+  userPlaceholder = 'Add a user ID…',
+  globalHint = 'No restrictions — visible to everyone (global).',
+  className,
+}: ScopeEditorProps) {
+  const isGlobal = value.organizationIds.length === 0 && value.userIds.length === 0;
+
+  return (
+    <div className={className}>
+      <ChipList
+        label={orgLabel}
+        placeholder={orgPlaceholder}
+        items={value.organizationIds}
+        disabled={disabled}
+        onAdd={(id) =>
+          onChange({ ...value, organizationIds: addUnique(value.organizationIds, id) })
+        }
+        onRemove={(id) =>
+          onChange({ ...value, organizationIds: value.organizationIds.filter((x) => x !== id) })
+        }
+      />
+      <div className="mt-4">
+        <ChipList
+          label={userLabel}
+          placeholder={userPlaceholder}
+          items={value.userIds}
+          disabled={disabled}
+          onAdd={(id) => onChange({ ...value, userIds: addUnique(value.userIds, id) })}
+          onRemove={(id) =>
+            onChange({ ...value, userIds: value.userIds.filter((x) => x !== id) })
+          }
+        />
+      </div>
+      {isGlobal && (
+        <p className="mt-3 flex items-center gap-2 text-sm text-muted-foreground">
+          <Globe className="h-4 w-4" />
+          {globalHint}
+        </p>
+      )}
+    </div>
+  );
+}
+
+function addUnique(list: string[], raw: string): string[] {
+  const value = raw.trim();
+  if (!value || list.includes(value)) return list;
+  return [...list, value];
+}
+
+interface ChipListProps {
+  label: string;
+  placeholder: string;
+  items: string[];
+  disabled: boolean;
+  onAdd: (id: string) => void;
+  onRemove: (id: string) => void;
+}
+
+function ChipList({ label, placeholder, items, disabled, onAdd, onRemove }: ChipListProps) {
+  const [draft, setDraft] = useState('');
+
+  const commit = () => {
+    if (draft.trim()) {
+      onAdd(draft);
+      setDraft('');
+    }
+  };
+
+  const handleKeyDown = (e: KeyboardEvent<HTMLInputElement>) => {
+    if (e.key === 'Enter') {
+      e.preventDefault();
+      commit();
+    }
+  };
+
+  return (
+    <div>
+      <Label className="text-sm">{label}</Label>
+      {items.length > 0 && (
+        <div className="mt-2 flex flex-wrap gap-2">
+          {items.map((id) => (
+            <Badge key={id} variant="secondary" className="gap-1 font-mono text-xs">
+              {id}
+              {!disabled && (
+                <button
+                  type="button"
+                  className="ml-1 rounded-sm hover:text-destructive"
+                  onClick={() => onRemove(id)}
+                  aria-label={`Remove ${id}`}
+                >
+                  <X className="h-3 w-3" />
+                </button>
+              )}
+            </Badge>
+          ))}
+        </div>
+      )}
+      <div className="mt-2 flex gap-2">
+        <Input
+          value={draft}
+          placeholder={placeholder}
+          disabled={disabled}
+          onChange={(e) => setDraft(e.target.value)}
+          onKeyDown={handleKeyDown}
+        />
+        <Button type="button" variant="outline" size="icon" disabled={disabled || !draft.trim()} onClick={commit}>
+          <Plus className="h-4 w-4" />
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/components/templates/TemplateEditDialog.tsx
+++ b/frontend/components/templates/TemplateEditDialog.tsx
@@ -35,6 +35,7 @@ import { Badge } from '@/components/ui/badge';
 import { useUpdateDocumentTemplate } from '@/hooks/use-document-templates';
 import { formatFileSize } from '@/lib/template-utils';
 import { getPlaceholderName } from '@/types/document-template';
+import { ScopeEditor, type ScopeValue } from '@/components/shared/ScopeEditor';
 import type { DocumentTemplate } from '@/types/document-template';
 
 // Max file size: 10MB
@@ -70,6 +71,7 @@ export function TemplateEditDialog({
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
   const [isDragging, setIsDragging] = useState(false);
   const [fileError, setFileError] = useState<string | null>(null);
+  const [scope, setScope] = useState<ScopeValue>({ organizationIds: [], userIds: [] });
 
   const updateMutation = useUpdateDocumentTemplate();
 
@@ -104,6 +106,10 @@ export function TemplateEditDialog({
         description_fr: template.description_fr || '',
         description_en: template.description_en || '',
         is_default: template.is_default,
+      });
+      setScope({
+        organizationIds: template.allowed_organization_ids ?? [],
+        userIds: template.allowed_user_ids ?? [],
       });
     }
     setSelectedFile(null);
@@ -191,6 +197,12 @@ export function TemplateEditDialog({
     if (data.is_default !== template.is_default) {
       formData.append('is_default', String(data.is_default));
     }
+
+    // Always replace the access scope with the editor's current value (supports
+    // clearing to a system template). replace_scope makes empty lists explicit.
+    formData.append('replace_scope', 'true');
+    scope.organizationIds.forEach((id) => formData.append('allowed_organization_ids', id));
+    scope.userIds.forEach((id) => formData.append('allowed_user_ids', id));
 
     // Append file if selected
     if (selectedFile) {
@@ -373,6 +385,21 @@ export function TemplateEditDialog({
                 />
               </TabsContent>
             </Tabs>
+
+            {/* Access scope (orgs/users). Both empty => system template. */}
+            <div className="rounded-md border p-4">
+              <p className="text-sm font-medium">{t('scope.title')}</p>
+              <p className="text-xs text-muted-foreground mt-1 mb-3">{t('scope.description')}</p>
+              <ScopeEditor
+                value={scope}
+                onChange={setScope}
+                orgLabel={t('scope.allowedOrganizations')}
+                userLabel={t('scope.allowedUsers')}
+                orgPlaceholder={t('scope.addOrganizationId')}
+                userPlaceholder={t('scope.addUserId')}
+                globalHint={t('scope.globalHint')}
+              />
+            </div>
 
             {/* Set as Default - only show in service context */}
             {showDefaultOption && (

--- a/frontend/components/templates/TemplateUpload.tsx
+++ b/frontend/components/templates/TemplateUpload.tsx
@@ -26,6 +26,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
 
 import { useUploadDocumentTemplate } from '@/hooks/use-document-templates';
 import { formatFileSize } from '@/lib/template-utils';
+import { ScopeEditor, type ScopeValue } from '@/components/shared/ScopeEditor';
 import type { DocumentTemplate } from '@/types/document-template';
 
 // Max file size: 10MB
@@ -43,6 +44,8 @@ interface TemplateUploadProps {
   serviceId?: string;
   /** Whether to show the "set as default" checkbox. Only relevant in service context. */
   showDefaultOption?: boolean;
+  /** Whether to show the access-scope editor (orgs/users). Default: true. */
+  showScopeEditor?: boolean;
   onSuccess: (template: DocumentTemplate) => void;
   onCancel?: () => void;
 }
@@ -55,6 +58,7 @@ export function TemplateUpload({
   userId,
   serviceId: _serviceId,
   showDefaultOption = true,
+  showScopeEditor = true,
   onSuccess,
   onCancel,
 }: TemplateUploadProps) {
@@ -64,6 +68,11 @@ export function TemplateUpload({
   const [selectedFile, setSelectedFile] = useState<File | null>(null);
   const [isDragging, setIsDragging] = useState(false);
   const [fileError, setFileError] = useState<string | null>(null);
+  // Access scope - seeded from the (optional) context props.
+  const [scope, setScope] = useState<ScopeValue>({
+    organizationIds: organizationId ? [organizationId] : [],
+    userIds: userId ? [userId] : [],
+  });
 
   const uploadMutation = useUploadDocumentTemplate();
 
@@ -175,12 +184,9 @@ export function TemplateUpload({
     if (data.description_en) {
       formData.append('description_en', data.description_en);
     }
-    if (organizationId) {
-      formData.append('organization_id', organizationId);
-    }
-    if (userId) {
-      formData.append('user_id', userId);
-    }
+    // Multi-scope access lists (repeat the field per ID). Empty => system template.
+    scope.organizationIds.forEach((id) => formData.append('allowed_organization_ids', id));
+    scope.userIds.forEach((id) => formData.append('allowed_user_ids', id));
 
     try {
       const template = await uploadMutation.mutateAsync(formData);
@@ -333,6 +339,23 @@ export function TemplateUpload({
             />
           </TabsContent>
         </Tabs>
+
+        {/* Access scope (orgs/users). Both empty => system template. */}
+        {showScopeEditor && (
+          <div className="rounded-md border p-4">
+            <p className="text-sm font-medium">{t('scope.title')}</p>
+            <p className="text-xs text-muted-foreground mt-1 mb-3">{t('scope.description')}</p>
+            <ScopeEditor
+              value={scope}
+              onChange={setScope}
+              orgLabel={t('scope.allowedOrganizations')}
+              userLabel={t('scope.allowedUsers')}
+              orgPlaceholder={t('scope.addOrganizationId')}
+              userPlaceholder={t('scope.addUserId')}
+              globalHint={t('scope.globalHint')}
+            />
+          </div>
+        )}
 
         {/* Set as Default - only shown in service context */}
         {showDefaultOption && (

--- a/frontend/hooks/use-services.ts
+++ b/frontend/hooks/use-services.ts
@@ -73,6 +73,19 @@ export const useDeleteService = () => {
   });
 };
 
+// Replace the set of document templates available for a service
+export const useSetServiceTemplates = () => {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: ({ id, templateIds }: { id: string; templateIds: string[] }) =>
+      apiClient.services.setTemplates(id, templateIds),
+    onSuccess: (_, variables) => {
+      queryClient.invalidateQueries({ queryKey: ['services'] });
+      queryClient.invalidateQueries({ queryKey: ['services', variables.id] });
+    },
+  });
+};
+
 // Execute service mutation
 export const useExecuteService = () => {
   return useMutation({

--- a/frontend/lib/api-client.ts
+++ b/frontend/lib/api-client.ts
@@ -153,6 +153,20 @@ export const apiClient = {
       return api.delete(`/api/v1/services/${id}`);
     },
 
+    // List the document templates available for a service (linked set, or the
+    // global default as fallback when none are linked).
+    listTemplates: async (
+      serviceId: string,
+      params?: { organization_id?: string; user_id?: string }
+    ): Promise<DocumentTemplate[]> => {
+      return api.get(`/api/v1/services/${serviceId}/templates`, { params });
+    },
+
+    // Replace the full set of document templates available for a service.
+    setTemplates: async (serviceId: string, templateIds: string[]): Promise<ServiceResponse> => {
+      return api.put(`/api/v1/services/${serviceId}/templates`, { template_ids: templateIds });
+    },
+
     execute: async (serviceId: string, formData: FormData): Promise<ExecuteServiceResponse> => {
       return api.post(`/api/v1/services/${serviceId}/run`, formData, {
         headers: { 'Content-Type': 'multipart/form-data' },

--- a/frontend/messages/en/services.json
+++ b/frontend/messages/en/services.json
@@ -102,7 +102,10 @@
     "descriptionFr": "Description (French)",
     "organizationId": "Organization ID",
     "flavors": "Flavors",
-    "flavorCount": "{count, plural, =0 {No flavors} =1 {1 flavor} other {# flavors}}"
+    "flavorCount": "{count, plural, =0 {No flavors} =1 {1 flavor} other {# flavors}}",
+    "scope": "Access scope",
+    "allowedOrganizations": "Allowed organizations",
+    "allowedUsers": "Allowed users"
   },
   "types": {
     "summary": "Summary",
@@ -127,7 +130,9 @@
     "name": "Enter service name",
     "descriptionEn": "English description",
     "descriptionFr": "French description",
-    "organizationId": "Organization UUID (e.g., 550e8400-e29b-41d4-a716-446655440000)"
+    "organizationId": "Organization UUID (e.g., 550e8400-e29b-41d4-a716-446655440000)",
+    "addOrganizationId": "Add an organization ID…",
+    "addUserId": "Add a user ID…"
   },
   "flavors": {
     "title": "Flavors",
@@ -343,5 +348,16 @@
     "previous": "Previous",
     "finish": "Create Flavor",
     "unsavedChanges": "Unsaved changes"
+  },
+  "scope": {
+    "globalHint": "No restrictions — this service is available to everyone (global)."
+  },
+  "availableTemplates": {
+    "title": "Available templates",
+    "description": "Choose which document templates can be used to export results of this service. If none are selected, the global default template is used.",
+    "save": "Save available templates",
+    "saved": "Available templates updated",
+    "empty": "No template linked — the global default template will be used.",
+    "add": "Add templates"
   }
 }

--- a/frontend/messages/en/templates.json
+++ b/frontend/messages/en/templates.json
@@ -35,7 +35,14 @@
   "scope": {
     "system": "System",
     "organization": "Organization",
-    "user": "Personal"
+    "user": "Personal",
+    "title": "Access scope",
+    "description": "Leave both lists empty to make this a system template visible to everyone.",
+    "allowedOrganizations": "Allowed organizations",
+    "allowedUsers": "Allowed users",
+    "addOrganizationId": "Add an organization ID…",
+    "addUserId": "Add a user ID…",
+    "globalHint": "No restrictions — system template, visible to everyone."
   },
   "fields": {
     "nameFr": "Name (French)",

--- a/frontend/messages/fr/services.json
+++ b/frontend/messages/fr/services.json
@@ -102,7 +102,10 @@
     "descriptionFr": "Description (français)",
     "organizationId": "ID d'organisation",
     "flavors": "Variantes",
-    "flavorCount": "{count, plural, =0 {Aucune variante} =1 {1 variante} other {# variantes}}"
+    "flavorCount": "{count, plural, =0 {Aucune variante} =1 {1 variante} other {# variantes}}",
+    "scope": "Portée d'accès",
+    "allowedOrganizations": "Organisations autorisées",
+    "allowedUsers": "Utilisateurs autorisés"
   },
   "types": {
     "summary": "Resume",
@@ -127,7 +130,9 @@
     "name": "Entrer le nom du service",
     "descriptionEn": "Description en anglais",
     "descriptionFr": "Description en français",
-    "organizationId": "UUID de l'organisation (ex: 550e8400-e29b-41d4-a716-446655440000)"
+    "organizationId": "UUID de l'organisation (ex: 550e8400-e29b-41d4-a716-446655440000)",
+    "addOrganizationId": "Ajouter un ID d'organisation…",
+    "addUserId": "Ajouter un ID d'utilisateur…"
   },
   "flavors": {
     "title": "Variantes",
@@ -343,5 +348,16 @@
     "previous": "Precedent",
     "finish": "Creer la variante",
     "unsavedChanges": "Modifications non sauvegardees"
+  },
+  "scope": {
+    "globalHint": "Aucune restriction — ce service est accessible à tous (global)."
+  },
+  "availableTemplates": {
+    "title": "Modèles disponibles",
+    "description": "Choisissez quels modèles de document peuvent être utilisés pour exporter les résultats de ce service. Si aucun n'est sélectionné, le modèle par défaut global est utilisé.",
+    "save": "Enregistrer les modèles disponibles",
+    "saved": "Modèles disponibles mis à jour",
+    "empty": "Aucun modèle lié — le modèle par défaut global sera utilisé.",
+    "add": "Ajouter des modèles"
   }
 }

--- a/frontend/messages/fr/templates.json
+++ b/frontend/messages/fr/templates.json
@@ -35,7 +35,14 @@
   "scope": {
     "system": "Systeme",
     "organization": "Organisation",
-    "user": "Personnel"
+    "user": "Personnel",
+    "title": "Portée d'accès",
+    "description": "Laissez les deux listes vides pour en faire un modèle système visible par tous.",
+    "allowedOrganizations": "Organisations autorisées",
+    "allowedUsers": "Utilisateurs autorisés",
+    "addOrganizationId": "Ajouter un ID d'organisation…",
+    "addUserId": "Ajouter un ID d'utilisateur…",
+    "globalHint": "Aucune restriction — modèle système, visible par tous."
   },
   "fields": {
     "nameFr": "Nom (francais)",

--- a/frontend/next.config.ts
+++ b/frontend/next.config.ts
@@ -1,5 +1,6 @@
 import type { NextConfig } from "next";
 import createNextIntlPlugin from 'next-intl/plugin';
+import pkg from './package.json';
 
 const withNextIntl = createNextIntlPlugin('./i18n/request.ts');
 
@@ -11,6 +12,11 @@ const basePath = process.env.BASE_PATH || undefined;
 const nextConfig: NextConfig = {
   output: 'standalone',
   basePath,
+  // Expose the app version (single source of truth: package.json) to the client
+  // so the footer version never drifts out of sync again.
+  env: {
+    NEXT_PUBLIC_APP_VERSION: pkg.version,
+  },
   typescript: {
     ignoreBuildErrors: false,
   },

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -1,6 +1,6 @@
 {
   "name": "llm-gateway-frontend",
-  "version": "2.4.0",
+  "version": "2.5.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/frontend/schemas/forms.ts
+++ b/frontend/schemas/forms.ts
@@ -136,8 +136,9 @@ export const serviceFormSchema = z.object({
     en: z.string().optional().default(''),
     fr: z.string().optional().default(''),
   }),
-  // Free-form organization identifier (any string up to 100 chars)
-  organization_id: z.string().max(100, 'validation.maxLength').nullable().optional(),
+  // Multi-scope access lists (free-form external IDs). Both empty => global service.
+  allowed_organization_ids: z.array(z.string().max(100)).optional().default([]),
+  allowed_user_ids: z.array(z.string().max(100)).optional().default([]),
   // Flavors are optional during creation - can be added later via Flavors tab
   flavors: z.array(flavorFormSchema).optional().default([]),
 });

--- a/frontend/types/document-template.ts
+++ b/frontend/types/document-template.ts
@@ -14,6 +14,10 @@ export interface DocumentTemplate {
   name_en: string | null;
   description_fr: string | null;
   description_en: string | null;
+  // Multi-scope access lists (both empty => system template).
+  allowed_organization_ids: string[];
+  allowed_user_ids: string[];
+  // Legacy single-scope fields, derived from the lists (kept for compat).
   organization_id: string | null;
   user_id: string | null;
   file_name: string;
@@ -47,6 +51,10 @@ export interface DocumentTemplateUpload {
   name_en?: string;
   description_fr?: string;
   description_en?: string;
+  // Multi-scope access lists (both empty => system template).
+  allowed_organization_ids?: string[];
+  allowed_user_ids?: string[];
+  // Deprecated single-scope aliases.
   organization_id?: string;
   user_id?: string;
   is_default?: boolean;
@@ -61,6 +69,9 @@ export interface DocumentTemplateUpdate {
   name_en?: string;
   description_fr?: string;
   description_en?: string;
+  // Replace the template scope (pass empty arrays for system scope).
+  allowed_organization_ids?: string[];
+  allowed_user_ids?: string[];
   is_default?: boolean;
 }
 

--- a/frontend/types/service.ts
+++ b/frontend/types/service.ts
@@ -168,8 +168,14 @@ export interface ServiceResponse {
   name: string;
   service_type: ServiceType;
   description: I18nDescription;
+  // Multi-scope access lists (both empty => global service).
+  allowed_organization_ids: string[];
+  allowed_user_ids: string[];
+  // Legacy single-org field, derived from the lists (kept for compat).
   organization_id: string;
   default_template_id?: string | null;
+  // Document templates available for this service (empty => global default).
+  template_ids?: string[];
   flavors: FlavorResponse[];
   created_at: string;
   updated_at: string;
@@ -231,15 +237,27 @@ export interface CreateServiceRequest {
   name: string;
   service_type: ServiceType;
   description: I18nDescription;
-  organization_id: string;
+  // Multi-scope access lists (both empty => global service).
+  allowed_organization_ids?: string[];
+  allowed_user_ids?: string[];
+  // Deprecated single-org alias (folded server-side into the lists).
+  organization_id?: string;
+  template_ids?: string[];
   flavors: CreateFlavorRequest[];
 }
 
 export interface UpdateServiceRequest {
   name?: string;
   description?: Partial<I18nDescription>;
+  allowed_organization_ids?: string[];
+  allowed_user_ids?: string[];
   organization_id?: string;
   default_template_id?: string | null;
+  template_ids?: string[];
+}
+
+export interface SetServiceTemplatesRequest {
+  template_ids: string[];
 }
 
 export interface UpdateFlavorRequest {
@@ -288,6 +306,7 @@ export interface UpdateFlavorRequest {
 
 export interface ServiceListFilters {
   organization_id?: string;
+  user_id?: string;
   service_type?: ServiceType;
   page?: number;
   page_size?: number;

--- a/tests/test_document_templates.py
+++ b/tests/test_document_templates.py
@@ -136,13 +136,13 @@ class TestDocumentTemplateModel:
         assert "updated_at" in columns
 
     def test_model_scope_property_system(self):
-        """Verify scope property returns 'system' when org_id=null, user_id=null."""
+        """Verify scope property returns 'system' when both access lists are empty."""
         from app.models.document_template import DocumentTemplate
         template = DocumentTemplate(
             id=uuid4(),
             name_fr="Test",
-            organization_id=None,
-            user_id=None,
+            allowed_organization_ids=[],
+            allowed_user_ids=[],
             file_path="test.docx",
             file_name="test.docx",
             file_size=1000,
@@ -151,13 +151,13 @@ class TestDocumentTemplateModel:
         assert template.scope == "system"
 
     def test_model_scope_property_organization(self):
-        """Verify scope property returns 'organization' when org_id=X, user_id=null."""
+        """Verify scope property returns 'organization' when only orgs are listed."""
         from app.models.document_template import DocumentTemplate
         template = DocumentTemplate(
             id=uuid4(),
             name_fr="Test",
-            organization_id=uuid4(),
-            user_id=None,
+            allowed_organization_ids=["org-1", "org-2"],
+            allowed_user_ids=[],
             file_path="test.docx",
             file_name="test.docx",
             file_size=1000,
@@ -166,13 +166,13 @@ class TestDocumentTemplateModel:
         assert template.scope == "organization"
 
     def test_model_scope_property_user(self):
-        """Verify scope property returns 'user' when org_id=X, user_id=Y."""
+        """Verify scope property returns 'user' when users are listed."""
         from app.models.document_template import DocumentTemplate
         template = DocumentTemplate(
             id=uuid4(),
             name_fr="Test",
-            organization_id=uuid4(),
-            user_id=uuid4(),
+            allowed_organization_ids=["org-1"],
+            allowed_user_ids=["user-1"],
             file_path="test.docx",
             file_name="test.docx",
             file_size=1000,
@@ -180,13 +180,15 @@ class TestDocumentTemplateModel:
         )
         assert template.scope == "user"
 
-    def test_model_has_check_constraint_user_requires_org(self):
-        """Verify database constraint: user_id requires organization_id."""
+    def test_model_has_multi_scope_columns(self):
+        """Verify the multi-scope access-list columns exist (and the old check constraint is gone)."""
         from app.models.document_template import DocumentTemplate
+        cols = DocumentTemplate.__table__.columns.keys()
+        assert "allowed_organization_ids" in cols
+        assert "allowed_user_ids" in cols
         constraints = [c.name for c in DocumentTemplate.__table__.constraints if hasattr(c, 'name')]
-        # The constraint should exist (check_user_requires_org)
-        assert any("user_requires_org" in (c or "") for c in constraints), \
-            "Must have constraint ensuring user_id requires organization_id"
+        assert not any("user_requires_org" in (c or "") for c in constraints), \
+            "check_user_requires_org should be dropped under the multi-scope model"
 
 
 # =============================================================================
@@ -224,31 +226,25 @@ class TestTemplateSchemas:
         fields = TemplateCreate.model_fields.keys()
         assert "name_fr" in fields
         assert "name_en" in fields
+        assert "allowed_organization_ids" in fields
+        assert "allowed_user_ids" in fields
+        # Deprecated single-scope aliases kept for backward compat
         assert "organization_id" in fields
         assert "user_id" in fields
         assert "is_default" in fields
 
-    def test_template_create_validates_user_requires_org(self):
-        """Verify TemplateCreate validation: user_id requires organization_id."""
+    def test_template_create_allows_user_only_scope(self):
+        """Under multi-scope, a user-only audience is allowed (no org required)."""
         from app.schemas.template import TemplateCreate
-        from pydantic import ValidationError
 
-        # Valid: no user_id
-        valid1 = TemplateCreate(name_fr="Test")
-        assert valid1.user_id is None
+        # Multi-scope: users without orgs is valid
+        t = TemplateCreate(name_fr="Test", allowed_user_ids=["user-1"])
+        assert t.allowed_user_ids == ["user-1"]
+        assert t.allowed_organization_ids == []
 
-        # Valid: both org and user (use strings for UUID fields)
-        valid2 = TemplateCreate(
-            name_fr="Test",
-            organization_id=str(uuid4()),
-            user_id=str(uuid4())
-        )
-        assert valid2.user_id is not None
-
-        # Invalid: user_id without organization_id (use string for UUID field)
-        with pytest.raises(ValidationError) as exc_info:
-            TemplateCreate(name_fr="Test", user_id=str(uuid4()))
-        assert "user_id requires organization_id" in str(exc_info.value)
+        # Deprecated single-scope aliases still accepted
+        t2 = TemplateCreate(name_fr="Test", user_id="user-1")
+        assert t2.user_id == "user-1"
 
     def test_template_update_schema_all_optional(self):
         """Verify TemplateUpdate schema has all optional fields."""
@@ -637,46 +633,39 @@ class TestVisibilityHierarchy:
     """Tests for visibility hierarchy per api-contract.md."""
 
     def test_system_scope_definition(self):
-        """System templates: org_id=null, user_id=null."""
+        """System templates: both access lists empty."""
         from app.models.document_template import DocumentTemplate
         template = DocumentTemplate(
             id=uuid4(), name_fr="System",
-            organization_id=None, user_id=None,
+            allowed_organization_ids=[], allowed_user_ids=[],
             file_path="t.docx", file_name="t.docx", file_size=100,
             mime_type="application/vnd.openxmlformats-officedocument.wordprocessingml.document"
         )
         assert template.scope == "system"
-        assert template.organization_id is None
-        assert template.user_id is None
 
     def test_organization_scope_definition(self):
-        """Org templates: org_id=X, user_id=null."""
+        """Org templates: orgs listed, no users."""
         from app.models.document_template import DocumentTemplate
-        org_id = uuid4()
         template = DocumentTemplate(
             id=uuid4(), name_fr="Org",
-            organization_id=org_id, user_id=None,
+            allowed_organization_ids=["org-1", "org-2"], allowed_user_ids=[],
             file_path="t.docx", file_name="t.docx", file_size=100,
             mime_type="application/vnd.openxmlformats-officedocument.wordprocessingml.document"
         )
         assert template.scope == "organization"
-        assert template.organization_id == org_id
-        assert template.user_id is None
+        assert "org-2" in template.allowed_organization_ids
 
     def test_user_scope_definition(self):
-        """User templates: org_id=X, user_id=Y."""
+        """User templates: users listed."""
         from app.models.document_template import DocumentTemplate
-        org_id = uuid4()
-        user_id = uuid4()
         template = DocumentTemplate(
             id=uuid4(), name_fr="User",
-            organization_id=org_id, user_id=user_id,
+            allowed_organization_ids=["org-1"], allowed_user_ids=["user-1", "user-2"],
             file_path="t.docx", file_name="t.docx", file_size=100,
             mime_type="application/vnd.openxmlformats-officedocument.wordprocessingml.document"
         )
         assert template.scope == "user"
-        assert template.organization_id == org_id
-        assert template.user_id == user_id
+        assert "user-2" in template.allowed_user_ids
 
 
 # =============================================================================


### PR DESCRIPTION
## Résumé
Permet de scoper services et templates de documents à **plusieurs** organisations et/ou utilisateurs (au lieu d'un seul), de gérer le scope des templates depuis l'admin, et d'associer explicitement un ensemble de templates à un service.

## Changements
- **Services & document_templates** : nouvelles listes `allowed_organization_ids` / `allowed_user_ids` (Postgres `text[]`, GIN). Listes vides = global/système. Colonnes legacy `organization_id`/`user_id` conservées et dérivées → compat LinTO Studio (qui lit encore `scope`/`user_id`).
- **Scope des templates éditable** : `PUT /document-templates/{id}` accepte les listes + `replace_scope` ; l'upload aussi.
- **Lien service ↔ templates** : table `service_document_templates` + `GET/PUT /services/{id}/templates`. Un service sans template lié retombe sur le template par défaut global.
- **UI admin** : composant `ScopeEditor` (chips), branché sur le formulaire service, l'upload/édition de template, et la page templates par service.
- **Migration alembic `008`** : ajoute les colonnes, backfill depuis les colonnes legacy, drop des contraintes obsolètes, crée la table de liaison.
- **Versions** : front 2.5.0, api 1.1.0 ; footer câblé sur `package.json` (fin du `0.1.0` codé en dur).

## Vérifs
Chaîne alembic `001→008` appliquée + round-trip sur vrai Postgres ; parité pytest avec `next` (zéro régression) ; ruff + tsc OK.