### PR TITLE
fix: resolve useFormField crash in ServiceForm Scope section

### DIFF
--- a/frontend/components/services/ServiceForm.tsx
+++ b/frontend/components/services/ServiceForm.tsx
@@ -14,6 +14,7 @@ import {
   FormMessage,
 } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
+import { Label } from '@/components/ui/label';
 import {
   Select,
   SelectContent,
@@ -200,11 +201,11 @@ export function ServiceForm({ service, onSuccess, onCancel }: ServiceFormProps) 
         />
 
         {/* Scope: allowed organizations and users (empty = global service) */}
-        <FormItem>
-          <FormLabel>
+        <div className="space-y-2">
+          <Label>
             {t('fields.scope')}{' '}
             <span className="text-muted-foreground text-xs">({tCommon('optional')})</span>
-          </FormLabel>
+          </Label>
           <ScopeEditor
             value={{
               organizationIds: form.watch('allowed_organization_ids') ?? [],
@@ -220,7 +221,7 @@ export function ServiceForm({ service, onSuccess, onCancel }: ServiceFormProps) 
             userPlaceholder={t('placeholders.addUserId')}
             globalHint={t('scope.globalHint')}
           />
-        </FormItem>
+        </div>
 
         {/* Actions */}
         <div className="flex justify-end gap-3">


### PR DESCRIPTION
The Scope section used <FormLabel> outside of a <FormField> context, causing 'useFormField should be used within <FormField>' at runtime when clicking 'Create new service'. Replace with plain <Label> since the scope editor is not a react-hook-form Controller field.